### PR TITLE
Add optional alpha layer to the floating list item

### DIFF
--- a/res/values/dslv_attrs.xml
+++ b/res/values/dslv_attrs.xml
@@ -13,5 +13,6 @@
       <enum name="slideLeft" value="2" />
     </attr>
     <attr name="track_drag_scroll" format="boolean"/>
+    <attr name="float_alpha" format="integer"/>
   </declare-styleable>
 </resources>

--- a/src/com/mobeta/android/dslv/DragSortListView.java
+++ b/src/com/mobeta/android/dslv/DragSortListView.java
@@ -79,6 +79,7 @@ public class DragSortListView extends ListView {
 	 * mDragPos = 1, then mDragPos points to the first list item after the header.
 	 */
 	private int mExpDragPos;
+	private int mFloatAlpha;
 	/**
 	 * At which position was the item being dragged originally
 	 */
@@ -157,6 +158,9 @@ public class DragSortListView extends ListView {
 
       mFloatBGColor = a.getColor(R.styleable.DragSortListView_float_background_color,
         0x00000000);
+
+      // alpha between 0 and 255, 0=transparent, 255=opaque
+      mFloatAlpha = a.getInt(R.styleable.DragSortListView_float_alpha, 255);
 
       mRemoveMode = a.getInt(R.styleable.DragSortListView_remove_mode, -1);
 
@@ -1126,6 +1130,7 @@ public class DragSortListView extends ListView {
 		ImageView v = new ImageView(context);
 		//int backGroundColor = context.getResources().getColor(R.color.dragndrop_background);
 		v.setBackgroundColor(mFloatBGColor);
+		v.setAlpha(mFloatAlpha);
 		//v.setBackgroundResource(R.drawable.playlist_tile_drag);
 		v.setPadding(0, 0, 0, 0);
 		v.setImageBitmap(bm);


### PR DESCRIPTION
I noticed the original music app has an alpha layer that it applies to the floating item.  Kind of nice visually, I think.  I like to set it to something like 128 (half-opaque), but the default here is 255 (fully opaque).

Fantastic library, by the way.  I was about to give up on finding a decent drag-and-drop list implementation until I found yours!
