### PR TITLE
Let the ListView handle item clicks and long-clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ News
 **Sept. 26, 2012**: Drag-sorting is now animated! (optional, of course)
 Items slide around underneath the floating (dragged) View.
 
-
 Overview
 --------
 
@@ -63,6 +62,11 @@ of 0 means a shuffle animation is always in progress, whereas a value
 of 1 means items snap from position to position without animation.
 * `remove_mode`: (enum, "none") One of "none" "fling", "slide",
 "slideRight", "slideLeft". This is inherited from the TI and may change.
+* `sort_mode`: (enum, "press") One of "none", "press", "longPress". Sets
+how a sort is started. The default, "press" means you just press and
+drag an item to sort it. "longPress" means you have to long-press a
+drag-handle to start sorting it: a normal drag just scrolls the list.
+"none" disables sorting. 
 * `track_drag_sort`: (bool, false) Debugging option; explained below.
 
 ### Listeners
@@ -134,11 +138,33 @@ Listener interfaces.
 A drag of item **i** is initiated when all the following are true:
 
 * A DragListener or DropListener (or DragSortListener) is
-registered with the DSLV instance.
-* A child View of item **i** has an `android:id` named `drag` (more
-on this below).
-* The touch screen DOWN event hits the child View with id `drag`.
+registered with the DSLV instance;
+* Item **i** contains a **drag handle** (defined below);
+* If the sort mode is `press`, there is a DOWN event on the drag handle
+followed by MOVE events;
+* If the sort mode is `longPress`, there is a DOWN event on the drag
+handle, followed by a pause long enough to be a long-press, followed by
+MOVE events. 
+* The touch screen DOWN event hits the drag handle.
 
+The "drag handle" referred to above is a child View of the item layout,
+with the `android:id` set to `@id/drag`. It can be any kind of View, but
+an ImageView is common. It can even be the root of the item layout if
+you like, but you then have to consider these interactions between
+different gestures:
+
+* If dragging is enabled and the sort mode is `press`, you won't be able
+to drag the list unless you make the padding wide enough to touch. You
+will still be able to click on and long-click on list items in the usual
+way: those actions take precedence over dragging. 
+* If dragging is enabled and the sort mode is `longPress`, you can click
+on list items, and drag the list in the usual way, but you won't be able
+to long-click on list items: in this mode, a long-press immediately
+floats the list item to give visual feedback to the user.
+
+These actually apply to any gesture that starts on a drag handle, but
+they're only really important when the whole item is the drag handle.
+ 
 An [example XML layout](https://github.com/bauerca/drag-sort-listview/blob/master/demo/res/layout/jazz_artist_list_item.xml)
 for a drag-sort-enabled ListView item can be found in the demo.
 The key line to note in the example is

--- a/demo/AndroidManifest.xml
+++ b/demo/AndroidManifest.xml
@@ -25,5 +25,7 @@
                   android:label="Arbitrary Item Size DSLV" />
         <activity android:name="Fling"
             	  android:label="Fling to remove DSLV" />
+        <activity android:name="ClickHandler"
+            	  android:label="Handle item clicks" />
     </application>
 </manifest> 

--- a/demo/AndroidManifest.xml
+++ b/demo/AndroidManifest.xml
@@ -27,5 +27,7 @@
             	  android:label="Fling to remove DSLV" />
         <activity android:name="ClickHandler"
             	  android:label="Handle item clicks" />
+        <activity android:name="LongPressToDrag"
+            	  android:label="Long-press to drag" />
     </application>
 </manifest> 

--- a/demo/AndroidManifest.xml
+++ b/demo/AndroidManifest.xml
@@ -4,6 +4,7 @@
       android:versionCode="1"
       android:versionName="1.0">
     <uses-sdk android:minSdkVersion="4" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <application android:label="@string/app_name" >
         <activity android:name="Launcher"
                   android:label="@string/app_name">
@@ -22,7 +23,7 @@
                   android:label="Header/Footer DSLV" />
         <activity android:name="ArbItemSizeDSLV"
                   android:label="Arbitrary Item Size DSLV" />
+        <activity android:name="Fling"
+            	  android:label="Fling to remove DSLV" />
     </application>
-    <uses-library android:name="com.mobeta.android.dslv" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest> 

--- a/demo/res/layout/list_item_handle_left.xml
+++ b/demo/res/layout/list_item_handle_left.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="@dimen/item1_height"
+  android:orientation="horizontal">
+  <ImageView
+    android:id="@id/drag"
+    android:background="@drawable/drag"
+    android:layout_width="wrap_content"
+    android:layout_height="@dimen/item1_height" />
+  <TextView
+    android:id="@+id/text1"
+    android:layout_width="wrap_content"
+    android:layout_height="@dimen/item1_height"
+    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+</LinearLayout>

--- a/demo/res/layout/list_item_no_handle.xml
+++ b/demo/res/layout/list_item_no_handle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@id/drag"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/item1_height"
+    android:textAppearance="?android:attr/textAppearanceMedium" />

--- a/demo/res/layout/main_fling.xml
+++ b/demo/res/layout/main_fling.xml
@@ -1,11 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<RelativeLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:dslv="http://schemas.android.com/apk/res/com.mobeta.android.demodslv"
   android:layout_width="fill_parent"
   android:layout_height="fill_parent">
-  <com.mobeta.android.dslv.FlingListView
-    android:id="@android:id/list"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent" />
-</LinearLayout>
+	<com.mobeta.android.dslv.DragSortListView
+	  android:id="@android:id/list"
+	  android:layout_width="fill_parent"
+	  android:layout_height="fill_parent"
+	  android:paddingTop="0dp"
+	  android:paddingBottom="0dp"
+		android:paddingLeft="10dp"
+		android:layout_margin="10dp"
+    android:dividerHeight="5dp"
+	  dslv:collapsed_height="2dp"
+	  dslv:drag_scroll_start="0.33"
+	  dslv:max_drag_scroll_speed="0.5"
+	  dslv:float_background_color="#000000"
+	  dslv:remove_mode="fling"
+    dslv:float_alpha="0.6"
+    dslv:slide_shuffle_speed="0.3"
+	  dslv:track_drag_sort="false" />
+</RelativeLayout>

--- a/demo/res/layout/main_long_press.xml
+++ b/demo/res/layout/main_long_press.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:dslv="http://schemas.android.com/apk/res/com.mobeta.android.demodslv"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent">
+	<com.mobeta.android.dslv.DragSortListView
+	  android:id="@android:id/list"
+	  android:layout_width="fill_parent"
+	  android:layout_height="fill_parent"
+	  android:paddingTop="0dp"
+	  android:paddingBottom="0dp"
+		android:paddingLeft="10dp"
+		android:layout_margin="10dp"
+    android:dividerHeight="5dp"
+	  dslv:collapsed_height="2dp"
+	  dslv:drag_scroll_start="0.33"
+	  dslv:max_drag_scroll_speed="0.5"
+	  dslv:float_background_color="#000000"
+	  dslv:sort_mode="longPress"
+    dslv:float_alpha="0.6"
+    dslv:slide_shuffle_speed="0.3"
+	  dslv:track_drag_sort="false" />
+</RelativeLayout>

--- a/demo/src/com/mobeta/android/demodslv/ArbItemSizeDSLV.java
+++ b/demo/src/com/mobeta/android/demodslv/ArbItemSizeDSLV.java
@@ -1,6 +1,5 @@
 package com.mobeta.android.demodslv;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -11,7 +10,6 @@ import com.mobeta.android.dslv.DragSortListView;
 import android.widget.TextView;
 import android.view.View;
 import android.view.ViewGroup;
-import android.util.Log;
 
 
 public class ArbItemSizeDSLV extends ListActivity {
@@ -88,7 +86,6 @@ public class ArbItemSizeDSLV extends ListActivity {
     }
 
     private class ViewHolder {
-      public TextView nameView;
       public TextView albumsView;
     }
 

--- a/demo/src/com/mobeta/android/demodslv/BasicDSLV.java
+++ b/demo/src/com/mobeta/android/demodslv/BasicDSLV.java
@@ -35,13 +35,20 @@ public class BasicDSLV extends ListActivity {
         }
       };
 
+    protected int getLayout() {
+        return R.layout.dslv_main;
+    }
+    
+    protected int getItemLayout() {
+        return R.layout.list_item1;
+    }
 
     /** Called when the activity is first created. */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         //setContentView(R.layout.main_fling);
-        setContentView(R.layout.dslv_main);
+        setContentView(getLayout());
 
         DragSortListView lv = (DragSortListView) getListView(); 
         lv.setDropListener(onDrop);
@@ -50,7 +57,7 @@ public class BasicDSLV extends ListActivity {
         array = getResources().getStringArray(R.array.jazz_artist_names);
         list = new ArrayList<String>(Arrays.asList(array));
 
-        adapter = new ArrayAdapter<String>(this, R.layout.list_item1, R.id.text1, list);
+        adapter = new ArrayAdapter<String>(this, getItemLayout(), R.id.text1, list);
         setListAdapter(adapter);
 
     }

--- a/demo/src/com/mobeta/android/demodslv/BasicDSLV.java
+++ b/demo/src/com/mobeta/android/demodslv/BasicDSLV.java
@@ -7,8 +7,6 @@ import android.app.ListActivity;
 import android.os.Bundle;
 import android.widget.ArrayAdapter;
 import com.mobeta.android.dslv.DragSortListView;
-import android.widget.TextView;
-import android.util.Log;
 
 
 public class BasicDSLV extends ListActivity {

--- a/demo/src/com/mobeta/android/demodslv/BasicLV.java
+++ b/demo/src/com/mobeta/android/demodslv/BasicLV.java
@@ -6,9 +6,6 @@ import java.util.ArrayList;
 import android.app.ListActivity;
 import android.os.Bundle;
 import android.widget.ArrayAdapter;
-import android.widget.ListView;
-import android.widget.TextView;
-import android.util.Log;
 
 
 public class BasicLV extends ListActivity {

--- a/demo/src/com/mobeta/android/demodslv/ClickHandler.java
+++ b/demo/src/com/mobeta/android/demodslv/ClickHandler.java
@@ -1,0 +1,75 @@
+package com.mobeta.android.demodslv;
+
+import java.util.ArrayList;
+
+import com.mobeta.android.dslv.DragSortListView;
+
+import android.app.ListActivity;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Toast;
+
+/** Demonstrate onItemClickListener and onItemLongClickListener.
+ * 
+ * Uses a list item layout where the whole layout is the drag handle, to demonstrate that tapping the child takes priority.
+ * Note that with the whole layout being the drag handle, you can't drag to scroll the layout.
+ */
+public class ClickHandler extends ListActivity {
+    private ArrayAdapter<String> adapter;
+
+    private String[] array;
+    private ArrayList<String> list;
+
+    private DragSortListView.DropListener onDrop =
+      new DragSortListView.DropListener() {
+        @Override
+        public void drop(int from, int to) {
+          String item = adapter.getItem(from);
+
+          adapter.remove(item);
+          adapter.insert(item, to);
+        }
+      };
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.dslv_main);
+
+        DragSortListView lv = (DragSortListView) getListView(); 
+        lv.setDropListener(onDrop);
+
+        int num = 5;
+
+        array = getResources().getStringArray(R.array.jazz_artist_names);
+        list = new ArrayList<String>();
+        for (int i = 0; i < num; ++i) {
+                list.add(array[i]);
+        }
+        adapter = new ArrayAdapter<String>(this, R.layout.list_item_no_handle, R.id.drag, list);
+        
+        setListAdapter(adapter);
+        
+        
+        lv.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> arg0, View arg1, int arg2,
+                    long arg3) {
+                String message = String.format("Clicked item %d", arg2);
+                Toast.makeText(ClickHandler.this, message, Toast.LENGTH_SHORT).show();
+                
+            }
+        });
+        lv.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
+            @Override
+            public boolean onItemLongClick(AdapterView<?> arg0, View arg1, int arg2,
+                    long arg3) {
+                String message = String.format("Long-clicked item %d", arg2);
+                Toast.makeText(ClickHandler.this, message, Toast.LENGTH_SHORT).show();
+                return true;
+            }
+        });
+    }
+}

--- a/demo/src/com/mobeta/android/demodslv/Fling.java
+++ b/demo/src/com/mobeta/android/demodslv/Fling.java
@@ -1,0 +1,13 @@
+package com.mobeta.android.demodslv;
+
+public class Fling extends BasicDSLV {
+    @Override
+    protected int getLayout() {
+        return R.layout.main_fling;
+    }
+	
+	@Override
+    protected int getItemLayout() {
+        return R.layout.list_item_handle_left;
+    }
+}

--- a/demo/src/com/mobeta/android/demodslv/HeadFootDSLV.java
+++ b/demo/src/com/mobeta/android/demodslv/HeadFootDSLV.java
@@ -8,7 +8,6 @@ import android.os.Bundle;
 import android.widget.ArrayAdapter;
 import com.mobeta.android.dslv.DragSortListView;
 import android.widget.TextView;
-import android.util.Log;
 
 
 public class HeadFootDSLV extends ListActivity {

--- a/demo/src/com/mobeta/android/demodslv/Launcher.java
+++ b/demo/src/com/mobeta/android/demodslv/Launcher.java
@@ -10,12 +10,10 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.util.Log;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.Intent;
-import android.content.ComponentName;
 
 //import com.mobeta.android.demodslv.R;
 

--- a/demo/src/com/mobeta/android/demodslv/Launcher.java
+++ b/demo/src/com/mobeta/android/demodslv/Launcher.java
@@ -36,6 +36,13 @@ public class Launcher extends ListActivity {
             "com.mobeta.android.demodslv", PackageManager.GET_ACTIVITIES);
 
           mActivities = new ArrayList<ActivityInfo>(Arrays.asList(pi.activities));
+          String ourName = getClass().getName();
+          for (int i = 0; i < mActivities.size(); ++i) {
+              if (ourName.equals(mActivities.get(i).name)) {
+                  mActivities.remove(i);
+                  break;
+              }
+          }
         } catch (PackageManager.NameNotFoundException e) {
           // Do nothing. Adapter will be empty.
         }
@@ -49,13 +56,9 @@ public class Launcher extends ListActivity {
 
     @Override
     protected void onListItemClick(ListView l, View v, int position, long id) {
-      Intent intent = new Intent();
-
-      if (position > 0) {
-        intent.setClassName(this, mActivities.get(position).name);
-        startActivity(intent);
-      }
-
+	    Intent intent = new Intent();
+	    intent.setClassName(this, mActivities.get(position).name);
+	    startActivity(intent);
     }
 
     private class MyAdapter extends ArrayAdapter<ActivityInfo> {

--- a/demo/src/com/mobeta/android/demodslv/LongPressToDrag.java
+++ b/demo/src/com/mobeta/android/demodslv/LongPressToDrag.java
@@ -1,0 +1,9 @@
+package com.mobeta.android.demodslv;
+
+/** Demonstrates starting a drag with a long-click. */
+public class LongPressToDrag extends BasicDSLV {
+    @Override
+    protected int getLayout() {
+        return R.layout.main_long_press;
+    }
+}

--- a/demo/src/com/mobeta/android/demodslv/ShortListDSLV.java
+++ b/demo/src/com/mobeta/android/demodslv/ShortListDSLV.java
@@ -1,14 +1,11 @@
 package com.mobeta.android.demodslv;
 
-import java.util.Arrays;
 import java.util.ArrayList;
 
 import android.app.ListActivity;
 import android.os.Bundle;
 import android.widget.ArrayAdapter;
 import com.mobeta.android.dslv.DragSortListView;
-import android.widget.TextView;
-import android.util.Log;
 
 
 public class ShortListDSLV extends ListActivity {

--- a/demo/src/com/mobeta/android/demodslv/WarpDSLV.java
+++ b/demo/src/com/mobeta/android/demodslv/WarpDSLV.java
@@ -7,8 +7,6 @@ import android.app.ListActivity;
 import android.os.Bundle;
 import android.widget.ArrayAdapter;
 import com.mobeta.android.dslv.DragSortListView;
-import android.widget.TextView;
-import android.util.Log;
 
 
 public class WarpDSLV extends ListActivity {

--- a/res/values/dslv_attrs.xml
+++ b/res/values/dslv_attrs.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <resources>
   <declare-styleable name="DragSortListView">
     <attr name="collapsed_height" format="dimension" />
@@ -15,5 +15,10 @@
     <attr name="track_drag_sort" format="boolean"/>
     <attr name="float_alpha" format="float"/>
     <attr name="slide_shuffle_speed" format="float"/>
+    <attr name="sort_mode">
+      <enum name="none" value="-1" />
+      <enum name="press" value="0" />
+      <enum name="longPress" value="1"/>
+    </attr>
   </declare-styleable>
 </resources>


### PR DESCRIPTION
Fixes issue #13 and provides a starting point for fixing issue #6. The touch-handling code moves around a lot, but it's really pretty similar. onInterceptTouchEvent and onTouchEvent now just forward events (when appropriate) to a GestureDetector, and the callbacks from the GestureDetector do the real dragging and arranging work. The crucial change is that onInterceptTouchEvent returns false most of the time, which lets AbsListView do its item click detection the way it usually does.

There's definitely more to do after this: slide-to-remove isn't any better than it was, and should be easily improved now; also, with drag-to-remove turned on and no drag listener, it should still be possible to scroll the list (like in the recent apps list), but currently isn't.
