### PR TITLE
add method to reset cursor mapping

### DIFF
--- a/library/src/com/mobeta/android/dslv/DragSortCursorAdapter.java
+++ b/library/src/com/mobeta/android/dslv/DragSortCursorAdapter.java
@@ -71,6 +71,14 @@ public abstract class DragSortCursorAdapter extends CursorAdapter implements Dra
         resetMappings();
     }
 
+    /**
+     * Resets list-cursor mapping.
+     */
+    public void reset() {
+        resetMappings();
+        notifyDataSetChanged();
+    }
+
     private void resetMappings() {
         mListMapping.clear();
         mRemovedCursorPositions.clear();


### PR DESCRIPTION
My client has the requirement that the listview is to be set in a special "drag/remove" (management) mode that allows cancelling all the operations.

Hence, I need a way to reset drag/remove state. See attached code to implement DragSortCursorAdapter.reset()
