### PR TITLE
Support for Checkable list items

### DIFF
--- a/demo/AndroidManifest.xml
+++ b/demo/AndroidManifest.xml
@@ -28,5 +28,9 @@
                   android:label="Sections" />
         <activity android:name="CursorDSLV"
                   android:label="Cursor-backed" />
+        <activity android:name="MultipleChoiceListView"
+                  android:label="Multi-select list" />
+        <activity android:name="SingleChoiceListView"
+                  android:label="Single-choice list" />
     </application>
 </manifest> 

--- a/demo/res/layout/checkable_main.xml
+++ b/demo/res/layout/checkable_main.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.mobeta.android.dslv.DragSortListView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:dslv="http://schemas.android.com/apk/res/com.mobeta.android.demodslv"
+    android:id="@android:id/list"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layout_margin="3dp"
+    android:choiceMode="multipleChoice"
+    android:dividerHeight="1px"
+    android:padding="3dp"
+    dslv:click_remove_id="@id/click_remove"
+    dslv:collapsed_height="1px"
+    dslv:drag_enabled="true"
+    dslv:drag_handle_id="@id/drag_handle"
+    dslv:drag_scroll_start="0.33"
+    dslv:drag_start_mode="onDown"
+    dslv:float_alpha="0.6"
+    dslv:remove_enabled="true"
+    dslv:remove_mode="clickRemove"
+    dslv:slide_shuffle_speed="0.3" />
+

--- a/demo/res/layout/list_item_checkable.xml
+++ b/demo/res/layout/list_item_checkable.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.mobeta.android.demodslv.CheckableLinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="@dimen/item_height"
+  android:orientation="horizontal">
+  <ImageView
+    android:id="@id/drag_handle"
+    android:background="@drawable/drag"
+    android:layout_width="wrap_content"
+    android:layout_height="@dimen/item_height"
+    android:layout_weight="0" />
+  <CheckedTextView
+    android:checkMark="?android:attr/listChoiceIndicatorMultiple"
+    android:id="@+id/text"
+    android:layout_width="wrap_content"
+    android:layout_height="@dimen/item_height"
+    android:layout_weight="1"
+    android:textAppearance="?android:attr/textAppearanceMedium"
+    android:gravity="center_vertical"
+    android:paddingLeft="8dp" />
+</com.mobeta.android.demodslv.CheckableLinearLayout>

--- a/demo/res/layout/list_item_checkable.xml
+++ b/demo/res/layout/list_item_checkable.xml
@@ -19,4 +19,10 @@
     android:textAppearance="?android:attr/textAppearanceMedium"
     android:gravity="center_vertical"
     android:paddingLeft="8dp" />
+  <ImageView
+    android:id="@id/click_remove"
+    android:background="@drawable/delete_x"
+    android:layout_width="@dimen/item_height"
+    android:layout_height="@dimen/item_height"
+    android:layout_weight="0" />
 </com.mobeta.android.demodslv.CheckableLinearLayout>

--- a/demo/res/layout/list_item_radio.xml
+++ b/demo/res/layout/list_item_radio.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.mobeta.android.demodslv.CheckableLinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="@dimen/item_height"
+  android:orientation="horizontal">
+  <ImageView
+    android:id="@id/drag_handle"
+    android:background="@drawable/drag"
+    android:layout_width="wrap_content"
+    android:layout_height="@dimen/item_height"
+    android:layout_weight="0" />
+  <CheckedTextView
+    android:checkMark="?android:attr/listChoiceIndicatorSingle"
+    android:id="@+id/text"
+    android:layout_width="wrap_content"
+    android:layout_height="@dimen/item_height"
+    android:layout_weight="1"
+    android:textAppearance="?android:attr/textAppearanceMedium"
+    android:gravity="center_vertical"
+    android:paddingLeft="8dp" />
+</com.mobeta.android.demodslv.CheckableLinearLayout>

--- a/demo/res/values/strings.xml
+++ b/demo/res/values/strings.xml
@@ -8,6 +8,8 @@
         <item>Background handle</item>
         <item>Sections</item>
         <item>CursorAdapter</item>
+        <item>Multiple-choice mode</item>
+        <item>Single-choice mode</item>
     </string-array>
     <string-array name="activity_descs">
         <item>
@@ -37,6 +39,13 @@
             Demonstrates usage of the DragSortCursorAdapter class,
             which abstracts drag-sorts with a remapping of Cursor
             positions to ListView positions.
+        </item>
+        <item>
+            Uses Checkable list items in multiple-choice mode.
+        </item>
+        <item>
+            Uses Checkable list items to allow for selectable radio
+            buttons in single-choice mode.
         </item>
     </string-array>
     <string name="ok">OK</string>

--- a/demo/src/com/mobeta/android/demodslv/CheckableLinearLayout.java
+++ b/demo/src/com/mobeta/android/demodslv/CheckableLinearLayout.java
@@ -1,0 +1,38 @@
+package com.mobeta.android.demodslv;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.Checkable;
+import android.widget.LinearLayout;
+
+public class CheckableLinearLayout extends LinearLayout implements Checkable {
+
+    private static final int CHECKABLE_CHILD_INDEX = 1;
+    private Checkable child;
+
+    public CheckableLinearLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+        child = (Checkable) getChildAt(CHECKABLE_CHILD_INDEX);
+    }
+
+    @Override
+    public boolean isChecked() {
+        return child.isChecked(); 
+    }
+
+    @Override
+    public void setChecked(boolean checked) {
+        child.setChecked(checked);
+    }
+
+    @Override
+    public void toggle() {
+        child.toggle();
+    }
+    
+}

--- a/demo/src/com/mobeta/android/demodslv/MultipleChoiceListView.java
+++ b/demo/src/com/mobeta/android/demodslv/MultipleChoiceListView.java
@@ -1,0 +1,52 @@
+package com.mobeta.android.demodslv;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import android.app.ListActivity;
+import android.os.Bundle;
+import android.widget.ArrayAdapter;
+
+import com.mobeta.android.dslv.DragSortListView;
+
+
+public class MultipleChoiceListView extends ListActivity
+{
+    private ArrayAdapter<String> adapter;
+
+    private DragSortListView.DropListener onDrop =
+        new DragSortListView.DropListener() {
+            @Override
+            public void drop(int from, int to) {
+                if (from != to) {
+                    DragSortListView list = getListView();
+                    String item = adapter.getItem(from);
+                    adapter.remove(item);
+                    adapter.insert(item, to);
+                    list.moveCheckState(from, to);
+                }
+            }
+        };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.checkable_main);
+        
+        String[] array = getResources().getStringArray(R.array.jazz_artist_names);
+        ArrayList<String> arrayList = new ArrayList<String>(Arrays.asList(array));
+
+        adapter = new ArrayAdapter<String>(this, R.layout.list_item_checkable, R.id.text, arrayList);
+        
+        setListAdapter(adapter);
+        
+        DragSortListView list = getListView();
+        list.setDropListener(onDrop);
+   }
+
+    @Override
+    public DragSortListView getListView() {
+        return (DragSortListView) super.getListView();
+    }
+    
+}

--- a/demo/src/com/mobeta/android/demodslv/MultipleChoiceListView.java
+++ b/demo/src/com/mobeta/android/demodslv/MultipleChoiceListView.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.widget.ArrayAdapter;
 
 import com.mobeta.android.dslv.DragSortListView;
+import com.mobeta.android.dslv.DragSortListView.RemoveListener;
 
 
 public class MultipleChoiceListView extends ListActivity
@@ -28,6 +29,17 @@ public class MultipleChoiceListView extends ListActivity
             }
         };
 
+    private RemoveListener onRemove =
+        new DragSortListView.RemoveListener() {
+            @Override
+            public void remove(int which) {
+                DragSortListView list = getListView();
+                String item = adapter.getItem(which);
+                adapter.remove(item);
+                list.removeCheckState(which);
+            }
+        };
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -42,6 +54,7 @@ public class MultipleChoiceListView extends ListActivity
         
         DragSortListView list = getListView();
         list.setDropListener(onDrop);
+        list.setRemoveListener(onRemove);
    }
 
     @Override

--- a/demo/src/com/mobeta/android/demodslv/SingleChoiceListView.java
+++ b/demo/src/com/mobeta/android/demodslv/SingleChoiceListView.java
@@ -1,0 +1,56 @@
+package com.mobeta.android.demodslv;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import android.app.ListActivity;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+
+import com.mobeta.android.dslv.DragSortListView;
+
+
+public class SingleChoiceListView extends ListActivity
+{
+    private ArrayAdapter<String> adapter;
+
+    private DragSortListView.DropListener onDrop =
+        new DragSortListView.DropListener() {
+            @Override
+            public void drop(int from, int to) {
+                if (from != to) {
+                    DragSortListView list = getListView();
+                    String item = adapter.getItem(from);
+                    adapter.remove(item);
+                    adapter.insert(item, to);
+                    list.moveCheckState(from, to);
+                    Log.d("DSLV", "Selected item is " + list.getCheckedItemPosition());
+                }
+            }
+        };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.checkable_main);
+        
+        String[] array = getResources().getStringArray(R.array.jazz_artist_names);
+        ArrayList<String> arrayList = new ArrayList<String>(Arrays.asList(array));
+
+        adapter = new ArrayAdapter<String>(this, R.layout.list_item_radio, R.id.text, arrayList);
+        
+        setListAdapter(adapter);
+        
+        DragSortListView list = getListView();
+        list.setDropListener(onDrop);
+        list.setChoiceMode(ListView.CHOICE_MODE_SINGLE);
+   }
+
+    @Override
+    public DragSortListView getListView() {
+        return (DragSortListView) super.getListView();
+    }
+    
+}

--- a/library/src/com/mobeta/android/dslv/DragSortItemView.java
+++ b/library/src/com/mobeta/android/dslv/DragSortItemView.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.View.MeasureSpec;
 import android.view.ViewGroup;
 import android.widget.AbsListView;
+import android.widget.Checkable;
 import android.util.Log;
 
 /**
@@ -23,7 +24,7 @@ import android.util.Log;
  * The purpose of this class is to optimize slide
  * shuffle animations.
  */
-public class DragSortItemView extends ViewGroup {
+public class DragSortItemView extends ViewGroup implements Checkable {
 
     private int mGravity = Gravity.TOP;
 
@@ -97,4 +98,26 @@ public class DragSortItemView extends ViewGroup {
         setMeasuredDimension(width, height);
     }
 
+    @Override
+    public boolean isChecked() {
+        View child = getChildAt(0);
+        if (child instanceof Checkable)
+            return ((Checkable) child).isChecked();
+        else
+            return false;
+    }
+
+    @Override
+    public void setChecked(boolean checked) {
+        View child = getChildAt(0);
+        if (child instanceof Checkable)
+            ((Checkable) child).setChecked(checked);
+    }
+
+    @Override
+    public void toggle() {
+        View child = getChildAt(0);
+        if (child instanceof Checkable)
+            ((Checkable) child).toggle();
+    }
 }

--- a/library/src/com/mobeta/android/dslv/DragSortListView.java
+++ b/library/src/com/mobeta/android/dslv/DragSortListView.java
@@ -2499,6 +2499,40 @@ public class DragSortListView extends ListView {
         }
     }
 
+    /**
+     * Use this when an item has been deleted, to move the check state of all
+     * preceding items up one step. If you have a choiceMode which is not none,
+     * this method must be called when the order of items changes in an
+     * underlying adapter which does not have stable IDs (see
+     * {@link ListAdapter#hasStableIds()}). This is because without IDs, the
+     * ListView has no way of knowing which items have moved where, and cannot
+     * update the check state accordingly.
+     * 
+     * See also further comments on {@link #moveCheckState(int, int)}.
+     * 
+     * @param position
+     */
+    public void removeCheckState(int position) {
+        SparseBooleanArray cip = getCheckedItemPositions();
+        
+        if (cip.size() == 0)
+            return;
+        int[] runStart = new int[cip.size()];
+        int[] runEnd = new int[cip.size()];
+        int rangeStart = position;
+        int rangeEnd = cip.keyAt(cip.size()-1)+1;
+        int runCount = buildRunList(cip, rangeStart, rangeEnd, runStart, runEnd);
+        for (int i=0; i!=runCount; i++) {
+            if (!(runStart[i] == position || (runEnd[i] < runStart[i] && runEnd[i] > position))) {
+                // Only set a new check mark in front of this run if it does
+                // not contain the deleted position. If it does, we only need
+                // to make it one check mark shorter at the end.
+                setItemChecked(rotate(runStart[i], - 1, rangeStart, rangeEnd), true);
+            }
+            setItemChecked(rotate(runEnd[i], - 1, rangeStart, rangeEnd), false);
+        }
+    }
+
     private static int buildRunList(SparseBooleanArray cip, int rangeStart,
             int rangeEnd, int[] runStart, int[] runEnd) {
         int runCount = 0;


### PR DESCRIPTION
When ListView has a choiceMode other than none, it can graphically
display which item(s) are currently selected, if (and only if) the list
items implement the Checkable interface. With DSLV, even if list items
implement this interface, it is hidden by the list-item wrapper used
(DragSortItemView).

With this change, DragSortItemView implements the Checkable interface
and forwards it to the wrapped item view if it implements Checkable,
allowing DSLV to function properly in all choice modes.

I considered a different design where we have a
CheckableDragSortItemView that inherits from DragSortItemView. DSLV
would then instantiate different variants depending on what is needed.
However, the only reason I could find for doing this would be to avoid
the few cycles spent on instanceof checks, and the original ListView
code does not seem to have any concerns about doing this (see
ListView.setupChild).
