### PR TITLE
added new remove mode (like in android notification area)

### DIFF
--- a/demo/res/layout/hetero_main.xml
+++ b/demo/res/layout/hetero_main.xml
@@ -22,4 +22,4 @@
     dslv:sort_enabled="true"
     dslv:remove_enabled="true"
     dslv:drag_start_mode="onDown"
-    dslv:remove_mode="flingLeft" />
+    dslv:remove_mode="flingRemove" />

--- a/demo/res/values/strings.xml
+++ b/demo/res/values/strings.xml
@@ -61,6 +61,7 @@
       <item>Fling left</item>
       <item>Slide right</item>
       <item>Slide left</item>
+      <item>Fling or Slide</item>
     </string-array>
     <string-array name="drag_init_mode_labels">
       <item>On down</item>

--- a/demo/res/values/strings.xml
+++ b/demo/res/values/strings.xml
@@ -57,11 +57,7 @@
     <string name="add_footer">Add footer</string>
     <string-array name="remove_mode_labels">
       <item>Click remove</item>
-      <item>Fling right</item>
-      <item>Fling left</item>
-      <item>Slide right</item>
-      <item>Slide left</item>
-      <item>Fling or Slide</item>
+      <item>Fling remove</item>
     </string-array>
     <string-array name="drag_init_mode_labels">
       <item>On down</item>

--- a/demo/src/com/mobeta/android/demodslv/DSLVFragment.java
+++ b/demo/src/com/mobeta/android/demodslv/DSLVFragment.java
@@ -53,9 +53,10 @@ public class DSLVFragment extends ListFragment {
      * Return list item layout resource passed to the ArrayAdapter.
      */
     protected int getItemLayout() {
-        if (removeMode == DragSortController.FLING_LEFT_REMOVE || removeMode == DragSortController.SLIDE_LEFT_REMOVE) {
+        /*if (removeMode == DragSortController.FLING_LEFT_REMOVE || removeMode == DragSortController.SLIDE_LEFT_REMOVE) {
             return R.layout.list_item_handle_right;
-        } else if (removeMode == DragSortController.CLICK_REMOVE) {
+        } else */
+    	if (removeMode == DragSortController.CLICK_REMOVE) {
             return R.layout.list_item_click_remove;
         } else {
             return R.layout.list_item_handle_left;
@@ -67,7 +68,7 @@ public class DSLVFragment extends ListFragment {
 
     public int dragStartMode = DragSortController.ON_DOWN;
     public boolean removeEnabled = false;
-    public int removeMode = DragSortController.FLING_RIGHT_REMOVE;
+    public int removeMode = DragSortController.FLING_REMOVE;
     public boolean sortEnabled = true;
     public boolean dragEnabled = true;
 

--- a/demo/src/com/mobeta/android/demodslv/RemoveModeDialog.java
+++ b/demo/src/com/mobeta/android/demodslv/RemoveModeDialog.java
@@ -21,7 +21,7 @@ public class RemoveModeDialog extends DialogFragment {
 
     public RemoveModeDialog() {
         super();
-        mRemoveMode = DragSortController.FLING_RIGHT_REMOVE;
+        mRemoveMode = DragSortController.FLING_REMOVE;
     }
 
     public RemoveModeDialog(int inRemoveMode) {

--- a/demo/src/com/mobeta/android/demodslv/TestBedDSLV.java
+++ b/demo/src/com/mobeta/android/demodslv/TestBedDSLV.java
@@ -27,9 +27,9 @@ EnablesDialog.EnabledOkListener
     private int mNumHeaders = 0;
     private int mNumFooters = 0;
 
-    private int mDragStartMode = DragSortController.ON_DOWN;
-    private boolean mRemoveEnabled = false;
-    private int mRemoveMode = DragSortController.FLING_RIGHT_REMOVE;
+    private int mDragStartMode = DragSortController.ON_DRAG;
+    private boolean mRemoveEnabled = true;
+    private int mRemoveMode = DragSortController.FLING_OR_SLIDE_REMOVE;
     private boolean mSortEnabled = true;
     private boolean mDragEnabled = true;
 

--- a/demo/src/com/mobeta/android/demodslv/TestBedDSLV.java
+++ b/demo/src/com/mobeta/android/demodslv/TestBedDSLV.java
@@ -29,7 +29,7 @@ EnablesDialog.EnabledOkListener
 
     private int mDragStartMode = DragSortController.ON_DRAG;
     private boolean mRemoveEnabled = true;
-    private int mRemoveMode = DragSortController.FLING_OR_SLIDE_REMOVE;
+    private int mRemoveMode = DragSortController.FLING_REMOVE;
     private boolean mSortEnabled = true;
     private boolean mDragEnabled = true;
 

--- a/library/res/values/dslv_attrs.xml
+++ b/library/res/values/dslv_attrs.xml
@@ -27,6 +27,7 @@
       <enum name="onLongPress" value="2"/>
     </attr>
     <attr name="drag_handle_id" format="integer" />
+    <attr name="fling_handle_id" format="integer" />
     <attr name="click_remove_id" format="integer" />
     <attr name="use_default_controller" format="boolean" />
   </declare-styleable>

--- a/library/res/values/dslv_attrs.xml
+++ b/library/res/values/dslv_attrs.xml
@@ -11,6 +11,7 @@
       <enum name="flingLeft" value="2" />
       <enum name="slideRight" value="3" />
       <enum name="slideLeft" value="4" />
+      <enum name="flingOrSlide" value="5" />
     </attr>
     <attr name="track_drag_sort" format="boolean"/>
     <attr name="float_alpha" format="float"/>

--- a/library/res/values/dslv_attrs.xml
+++ b/library/res/values/dslv_attrs.xml
@@ -7,11 +7,7 @@
     <attr name="float_background_color" format="color" />
     <attr name="remove_mode">
       <enum name="clickRemove" value="0" />
-      <enum name="flingRight" value="1" />
-      <enum name="flingLeft" value="2" />
-      <enum name="slideRight" value="3" />
-      <enum name="slideLeft" value="4" />
-      <enum name="flingOrSlide" value="5" />
+      <enum name="flingRemove" value="1" />
     </attr>
     <attr name="track_drag_sort" format="boolean"/>
     <attr name="float_alpha" format="float"/>

--- a/library/src/com/mobeta/android/dslv/DragSortController.java
+++ b/library/src/com/mobeta/android/dslv/DragSortController.java
@@ -274,6 +274,7 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
                 }
             }
         case MotionEvent.ACTION_CANCEL:
+        	mIsRemoving = false; 
             mDragging = false;
             break;
         }
@@ -407,10 +408,12 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
         }
 
         mHitPos = startDragPosition(ev);
-        if (mHitPos != MISS && mDragInitMode == ON_DOWN && mRemoveMode!=FLING_OR_SLIDE_REMOVE) {
-            startDrag(mHitPos, (int) ev.getX() - mItemX, (int) ev.getY() - mItemY);
+        mRemoveHitPos = MISS;
+        boolean startedDrag = false;
+        if (mHitPos != MISS && mDragInitMode == ON_DOWN ) {
+        	startedDrag = startDrag(mHitPos, (int) ev.getX() - mItemX, (int) ev.getY() - mItemY);
         }
-        if( mRemoveMode == FLING_OR_SLIDE_REMOVE )
+        if( !startedDrag && mRemoveMode == FLING_OR_SLIDE_REMOVE )
         {
             mCanDrag = true;
             mPositionX = 0;
@@ -476,7 +479,7 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
     @Override
     public void onLongPress(MotionEvent e) {
         //Log.d("mobeta", "lift listener long pressed");
-        if (mHitPos != MISS && mDragInitMode == ON_LONG_PRESS && mRemoveMode!=FLING_OR_SLIDE_REMOVE) {
+        if (mHitPos != MISS && mDragInitMode == ON_LONG_PRESS ) {
             mDslv.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
             startDrag(mHitPos, mCurrX - mItemX, mCurrY - mItemY);
         }
@@ -510,6 +513,7 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
                 @Override
                 public final boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
                     //Log.d("mobeta", "on fling remove called");
+                   	mIsRemoving = false;
                     if (mRemoveEnabled) {
                     	switch (mRemoveMode) {
                     	case FLING_OR_SLIDE_REMOVE:
@@ -522,20 +526,12 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
                                 	{
                                 		mDslv.stopDragWithVelocity(true,velocityX);
                                 	}
-                                	else
-                                	{	
-                                		mIsRemoving = false;
-                                	}
                                 }
                                 else if (velocityX < -mFlingSpeed ) 
                                 {
                                 	if( mPositionX < minPos )
                                 	{
                                 		mDslv.stopDragWithVelocity(true,velocityX);
-                                	}
-                                	else
-                                	{
-                                		mIsRemoving = false;
                                 	}
                                 }
                     		}

--- a/library/src/com/mobeta/android/dslv/DragSortController.java
+++ b/library/src/com/mobeta/android/dslv/DragSortController.java
@@ -44,7 +44,7 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
     private int mRemoveMode;
 
     private boolean mRemoveEnabled = false;
-	private boolean mIsRemoving = false;
+    private boolean mIsRemoving = false;
 
     private GestureDetector mDetector;
 
@@ -79,8 +79,7 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
     private boolean mCanDrag;
 
     private DragSortListView mDslv;
-	private int mPositionX;
-
+    private int mPositionX;
 
     /**
      * Calls {@link #DragSortController(DragSortListView, int)} with a
@@ -97,9 +96,9 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
     public DragSortController(DragSortListView dslv, int dragHandleId, int dragInitMode, int removeMode) {
         this(dslv, dragHandleId, dragInitMode, removeMode, 0);
     }
-    public DragSortController(DragSortListView dslv, int dragHandleId, int dragInitMode, int removeMode, int clickRemoveId)
-    {
-    	this(dslv, dragHandleId, dragInitMode, removeMode, clickRemoveId,0);
+
+    public DragSortController(DragSortListView dslv, int dragHandleId, int dragInitMode, int removeMode, int clickRemoveId) {
+        this(dslv, dragHandleId, dragInitMode, removeMode, clickRemoveId, 0);
     }
 
     /**
@@ -109,8 +108,8 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
      * @param dragHandleId The resource id of the View that represents
      * the drag handle in a list item.
      */
-    public DragSortController(DragSortListView dslv, int dragHandleId, int dragInitMode, int removeMode, int clickRemoveId, int flingHandleId) 
-    {
+    public DragSortController(DragSortListView dslv, int dragHandleId, int dragInitMode,
+            int removeMode, int clickRemoveId, int flingHandleId) {
         super(dslv);
         mDslv = dslv;
         mDetector = new GestureDetector(dslv.getContext(), this);
@@ -186,8 +185,8 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
      */
     public void setDragHandleId(int id) {
         mDragHandleId = id;
-    }  
-    
+    }
+
     /**
      * Set the resource id for the View that represents the fling
      * handle in a list item.
@@ -208,7 +207,6 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
         mClickRemoveId = id;
     }
 
-
     /**
      * Sets flags to restrict certain motions of the floating View
      * based on DragSortController settings (such as remove mode).
@@ -220,18 +218,19 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
      *
      * @return True if drag started, false otherwise.
      */
-     public boolean startDrag(int position, int deltaX, int deltaY) {
+    public boolean startDrag(int position, int deltaX, int deltaY) {
 
         int dragFlags = 0;
         if (mSortEnabled && !mIsRemoving) {
             dragFlags |= DragSortListView.DRAG_POS_Y | DragSortListView.DRAG_NEG_Y;
         }
-        if (mRemoveEnabled && mIsRemoving){
-        	dragFlags |= DragSortListView.DRAG_POS_X;
-        	dragFlags |= DragSortListView.DRAG_NEG_X;
+        if (mRemoveEnabled && mIsRemoving) {
+            dragFlags |= DragSortListView.DRAG_POS_X;
+            dragFlags |= DragSortListView.DRAG_NEG_X;
         }
-        
-        mDragging = mDslv.startDrag(position - mDslv.getHeaderViewsCount(), dragFlags, deltaX, deltaY);
+
+        mDragging = mDslv.startDrag(position - mDslv.getHeaderViewsCount(), dragFlags, deltaX,
+                deltaY);
         return mDragging;
     }
 
@@ -242,29 +241,29 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
         }
 
         mDetector.onTouchEvent(ev);
-        if (mRemoveEnabled && mDragging && mRemoveMode == FLING_REMOVE ) {
+        if (mRemoveEnabled && mDragging && mRemoveMode == FLING_REMOVE) {
             mFlingRemoveDetector.onTouchEvent(ev);
         }
 
         int action = ev.getAction() & MotionEvent.ACTION_MASK;
 
         switch (action) {
-        case MotionEvent.ACTION_DOWN:
-            mCurrX = (int) ev.getX();
-            mCurrY = (int) ev.getY();
-            break;
-        case MotionEvent.ACTION_UP:
-            if (mRemoveEnabled && mIsRemoving ) {
-                int x = mPositionX >= 0 ? mPositionX : -mPositionX;
-                int removePoint = mDslv.getWidth() / 2;
-                if( x > removePoint ){
-                	mDslv.stopDragWithVelocity(true,0);
+            case MotionEvent.ACTION_DOWN:
+                mCurrX = (int) ev.getX();
+                mCurrY = (int) ev.getY();
+                break;
+            case MotionEvent.ACTION_UP:
+                if (mRemoveEnabled && mIsRemoving) {
+                    int x = mPositionX >= 0 ? mPositionX : -mPositionX;
+                    int removePoint = mDslv.getWidth() / 2;
+                    if (x > removePoint) {
+                        mDslv.stopDragWithVelocity(true, 0);
+                    }
                 }
-            }
-        case MotionEvent.ACTION_CANCEL:
-        	mIsRemoving = false; 
-            mDragging = false;
-            break;
+            case MotionEvent.ACTION_CANCEL:
+                mIsRemoving = false;
+                mDragging = false;
+                break;
         }
 
         return false;
@@ -276,7 +275,7 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
     @Override
     public void onDragFloatView(View floatView, Point position, Point touch) {
 
-        if (mRemoveEnabled &&  mIsRemoving ){
+        if (mRemoveEnabled && mIsRemoving) {
             mPositionX = position.x;
         }
     }
@@ -297,8 +296,9 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
     public int startDragPosition(MotionEvent ev) {
         return dragHandleHitPosition(ev);
     }
+
     public int startFlingPosition(MotionEvent ev) {
-    	return mRemoveMode == FLING_REMOVE ? flingHandleHitPosition(ev) : MISS;
+        return mRemoveMode == FLING_REMOVE ? flingHandleHitPosition(ev) : MISS;
     }
 
     /**
@@ -314,32 +314,34 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
     public int dragHandleHitPosition(MotionEvent ev) {
         return viewIdHitPosition(ev, mDragHandleId);
     }
+
     public int flingHandleHitPosition(MotionEvent ev) {
-    	return viewIdHitPosition(ev, mFlingHandleId);
+        return viewIdHitPosition(ev, mFlingHandleId);
     }
 
     public int viewIdHitPosition(MotionEvent ev, int id) {
         final int x = (int) ev.getX();
         final int y = (int) ev.getY();
 
-        int touchPos = mDslv.pointToPosition(x, y); //includes headers/footers
-        
+        int touchPos = mDslv.pointToPosition(x, y); // includes headers/footers
+
         final int numHeaders = mDslv.getHeaderViewsCount();
         final int numFooters = mDslv.getFooterViewsCount();
         final int count = mDslv.getCount();
-        
-        //Log.d("mobeta", "touch down on position " + itemnum);
+
+        // Log.d("mobeta", "touch down on position " + itemnum);
         // We're only interested if the touch was on an
         // item that's not a header or footer.
-        if (touchPos != AdapterView.INVALID_POSITION && touchPos >= numHeaders && touchPos < (count - numFooters)) {
+        if (touchPos != AdapterView.INVALID_POSITION && touchPos >= numHeaders
+                && touchPos < (count - numFooters)) {
             final View item = mDslv.getChildAt(touchPos - mDslv.getFirstVisiblePosition());
             final int rawX = (int) ev.getRawX();
             final int rawY = (int) ev.getRawY();
-        
+
             View dragBox = id == 0 ? item : (View) item.findViewById(id);
             if (dragBox != null) {
                 dragBox.getLocationOnScreen(mTempLoc);
-                
+
                 if (rawX > mTempLoc[0] && rawY > mTempLoc[1] &&
                         rawX < mTempLoc[0] + dragBox.getWidth() &&
                         rawY < mTempLoc[1] + dragBox.getHeight()) {
@@ -362,10 +364,10 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
         }
 
         mHitPos = startDragPosition(ev);
-        if (mHitPos != MISS && mDragInitMode == ON_DOWN ) {
-        	startDrag(mHitPos, (int) ev.getX() - mItemX, (int) ev.getY() - mItemY);
+        if (mHitPos != MISS && mDragInitMode == ON_DOWN) {
+            startDrag(mHitPos, (int) ev.getX() - mItemX, (int) ev.getY() - mItemY);
         }
-        
+
         mIsRemoving = false;
         mCanDrag = true;
         mPositionX = 0;
@@ -373,7 +375,7 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
 
         return true;
     }
-    
+
     @Override
     public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
 
@@ -381,48 +383,37 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
         final int y1 = (int) e1.getY();
         final int x2 = (int) e2.getX();
         final int y2 = (int) e2.getY();
-        final int deltaX = x2-mItemX;
-        final int deltaY = y2-mItemY;
-    	
-    	if( mCanDrag && !mDragging && (mHitPos != MISS || mFlingHitPos !=MISS )) {
-            
-            if( mHitPos != MISS  )
-            {
-            	if( mDragInitMode == ON_DRAG )
-            	{
-            		if( Math.abs(y2-y1)>mTouchSlop && mSortEnabled )
-            		{
-            			startDrag(mHitPos, deltaX, deltaY);
-            		}
-            		else if( Math.abs(x2 - x1) > mTouchSlop && mRemoveEnabled )
-            		{
-               			mIsRemoving  = true;
-               			startDrag(mFlingHitPos, deltaX, deltaY);
-            		}
-            	}
-            	//if mDragInitMode != ON_DRAG shloudn't do anything
+        final int deltaX = x2 - mItemX;
+        final int deltaY = y2 - mItemY;
+
+        if (mCanDrag && !mDragging && (mHitPos != MISS || mFlingHitPos != MISS)) {
+            if (mHitPos != MISS) {
+                if (mDragInitMode == ON_DRAG && Math.abs(y2 - y1) > mTouchSlop && mSortEnabled) {
+                    startDrag(mHitPos, deltaX, deltaY);
+                }
+                else if (mDragInitMode != ON_DOWN && Math.abs(x2 - x1) > mTouchSlop && mRemoveEnabled)
+                {
+                    mIsRemoving = true;
+                    startDrag(mFlingHitPos, deltaX, deltaY);
+                }
+            } else if (mFlingHitPos != MISS) {
+                if (Math.abs(x2 - x1) > mTouchSlop && mRemoveEnabled) {
+                    mIsRemoving = true;
+                    startDrag(mFlingHitPos, deltaX, deltaY);
+                } else if (Math.abs(y2 - y1) > mTouchSlop) {
+                    mCanDrag = false; // if started to scroll the list then
+                                      // don't allow sorting nor fling-removing
+                }
             }
-            else if( mFlingHitPos != MISS)
-            {
-            	if( Math.abs(x2 - x1) > mTouchSlop && mRemoveEnabled)
-            	{
-           			mIsRemoving  = true;
-           			startDrag(mFlingHitPos, deltaX, deltaY);
-            	}
-				else if( Math.abs(y2-y1) > mTouchSlop)
-				{
-					mCanDrag = false; //if started to scroll the list then don't allow sorting nor fling-removing
-				}
-            }
-    	}
+        }
         // return whatever
         return false;
     }
 
     @Override
     public void onLongPress(MotionEvent e) {
-        //Log.d("mobeta", "lift listener long pressed");
-        if (mHitPos != MISS && mDragInitMode == ON_LONG_PRESS ) {
+        // Log.d("mobeta", "lift listener long pressed");
+        if (mHitPos != MISS && mDragInitMode == ON_LONG_PRESS) {
             mDslv.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
             startDrag(mHitPos, mCurrX - mItemX, mCurrY - mItemY);
         }
@@ -454,24 +445,20 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
     private GestureDetector.OnGestureListener mFlingRemoveListener =
             new GestureDetector.SimpleOnGestureListener() {
                 @Override
-                public final boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
-                    //Log.d("mobeta", "on fling remove called");
-                    if (mRemoveEnabled && mIsRemoving ) {
-                    	int w = mDslv.getWidth();
-                    	int minPos = w/5;
-                        if (velocityX > mFlingSpeed ) 
-                        {
-                        	if( mPositionX > -minPos )
-                        	{
-                        		mDslv.stopDragWithVelocity(true,velocityX);
-                        	}
-                        }
-                        else if (velocityX < -mFlingSpeed ) 
-                        {
-                        	if( mPositionX < minPos )
-                        	{
-                        		mDslv.stopDragWithVelocity(true,velocityX);
-                        	}
+                public final boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX,
+                        float velocityY) {
+                    // Log.d("mobeta", "on fling remove called");
+                    if (mRemoveEnabled && mIsRemoving) {
+                        int w = mDslv.getWidth();
+                        int minPos = w / 5;
+                        if (velocityX > mFlingSpeed) {
+                            if (mPositionX > -minPos) {
+                                mDslv.stopDragWithVelocity(true, velocityX);
+                            }
+                        } else if (velocityX < -mFlingSpeed) {
+                            if (mPositionX < minPos) {
+                                mDslv.stopDragWithVelocity(true, velocityX);
+                            }
                         }
                         mIsRemoving = false;
                     }
@@ -480,4 +467,3 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
             };
 
 }
-

--- a/library/src/com/mobeta/android/dslv/DragSortListView.java
+++ b/library/src/com/mobeta/android/dslv/DragSortListView.java
@@ -431,12 +431,15 @@ public class DragSortListView extends ListView {
      */
     private static final int sCacheSize = 3;
     private HeightCache mChildHeightCache = new HeightCache(sCacheSize);
-
+	
     private RemoveAnimator mRemoveAnimator;
 
     private LiftAnimator mLiftAnimator;
 
     private DropAnimator mDropAnimator;
+
+	private boolean mUseRemoveVelocity;
+    private float mRemoveVelocityX = 0;
 
     public DragSortListView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -732,7 +735,21 @@ public class DragSortListView extends ListView {
             // draw the float view over everything
             final int w = mFloatView.getWidth();
             final int h = mFloatView.getHeight();
-            final int alpha = (int) (255f * mCurrFloatAlpha);
+            
+            int x = mFloatLoc.x;
+
+            int width = getWidth();
+            if(x<0) 
+            	x = -x;
+			float alphaMod;
+			if (x < width) {
+				alphaMod = ((float) (width - x)) / ((float) width);
+			    alphaMod *= alphaMod;
+			} else {
+				alphaMod = 0;
+			}
+			
+            final int alpha = (int) (255f * mCurrFloatAlpha * alphaMod );
 
             canvas.save();
             //Log.d("mobeta", "clip rect bounds: " + canvas.getClipBounds());
@@ -1041,7 +1058,7 @@ public class DragSortListView extends ListView {
     }
 
     private class SmoothAnimator implements Runnable {
-        private long mStartTime;
+        protected long mStartTime;
 
         private float mDurationF;
 
@@ -1188,9 +1205,11 @@ public class DragSortListView extends ListView {
         @Override
         public void onUpdate(float frac, float smoothFrac) {
             final int targetY = getTargetY();
+            final int targetX = getPaddingLeft();
             final float deltaY = mFloatLoc.y - targetY;
+            final float deltaX = mFloatLoc.x - targetX;
             final float f = 1f - smoothFrac;
-            if (f < Math.abs(deltaY / mInitDeltaY)) {
+            if (f < Math.abs(deltaY / mInitDeltaY) || f<Math.abs(deltaX / mInitDeltaX)) {
                 mFloatLoc.y = targetY + (int) (mInitDeltaY * f);
                 mFloatLoc.x = getPaddingLeft() + (int) (mInitDeltaX * f);
                 doDragFloatView(true);
@@ -1209,6 +1228,7 @@ public class DragSortListView extends ListView {
      */
     private class RemoveAnimator extends SmoothAnimator {
 
+    	private float mFloatLocX;
         private float mFirstStartBlank;
         private float mSecondStartBlank;
 
@@ -1231,7 +1251,26 @@ public class DragSortListView extends ListView {
             mSecondPos = mSecondExpPos;
             srcPos = mSrcPos;
             mDragState = REMOVING;
-            destroyFloatView();
+
+            mFloatLocX = mFloatLoc.x;
+            if( mUseRemoveVelocity )
+            {
+            	float minVelocity = 2f*getWidth();
+            	if( mRemoveVelocityX == 0)
+            		mRemoveVelocityX = (mFloatLocX < 0 ? -1 : 1)*minVelocity;
+            	else
+            	{
+            		minVelocity *= 2;
+            		if( mRemoveVelocityX < 0 && mRemoveVelocityX > -minVelocity)
+            			mRemoveVelocityX = -minVelocity;
+            		else if( mRemoveVelocityX > 0 && mRemoveVelocityX < minVelocity)
+            			mRemoveVelocityX = minVelocity;
+            	}
+            }
+			else
+			{	
+	            destroyFloatView();
+			}
         }
 
         @Override
@@ -1242,6 +1281,25 @@ public class DragSortListView extends ListView {
             View item = getChildAt(mFirstPos - firstVis);
             ViewGroup.LayoutParams lp;
             int blank;
+            
+            if( mUseRemoveVelocity )
+            {
+				float dt = (float)(SystemClock.uptimeMillis() - mStartTime)/1000;
+				if( dt == 0 )
+					return;
+				float dx =  mRemoveVelocityX*dt;
+				int w = getWidth();
+				mRemoveVelocityX += (mRemoveVelocityX > 0 ? 1 :-1)*dt*w; 
+				mFloatLocX += dx;
+				mFloatLoc.x = (int) mFloatLocX;
+				if( mFloatLocX < w && mFloatLocX > -w)
+				{
+					mStartTime = SystemClock.uptimeMillis();
+					doDragFloatView(true);
+					return;
+				}
+            }
+			
             if (item != null) {
                 if (mFirstChildHeight == -1) {
                     mFirstChildHeight = getChildHeight(mFirstPos, item, false);
@@ -1273,14 +1331,24 @@ public class DragSortListView extends ListView {
         }
     }
 
+
+    public void removeItem(int which ) {
+
+    	mUseRemoveVelocity = false;
+    	removeItem( which, 0 );
+    }
     /**
      * Removes an item from the list and animates the removal.
      *
      * @param which Position to remove (NOTE: headers/footers ignored!
      * this is a position in your input ListAdapter).
+     * @param velocityX 
      */
-    public void removeItem(int which) {
+    public void removeItem(int which, float velocityX) {
         if (mDragState == IDLE || mDragState == DRAGGING) {
+
+            mDragState = REMOVING;
+        	mRemoveVelocityX = velocityX;
             if (mDragState == IDLE) {
                 // called from outside drag-sort
                 mSrcPos = getHeaderViewsCount() + which;
@@ -1439,11 +1507,20 @@ public class DragSortListView extends ListView {
      * no floating View.
      */
     public boolean stopDrag(boolean remove) {
+    	mUseRemoveVelocity = false;
+    	return stopDrag( remove, 0 );
+    }
+    public boolean stopDragWithVelocity(boolean remove, float velocityX) {
+    	
+    	mUseRemoveVelocity = true;
+    	return stopDrag( remove, velocityX );
+    }
+    public boolean stopDrag(boolean remove, float velocityX) {
         if (mFloatView != null) {
             mDragScroller.stopScrolling(true);
             
             if (remove) {
-                removeItem(mSrcPos - getHeaderViewsCount());
+                removeItem(mSrcPos - getHeaderViewsCount(),velocityX);
             } else {
                 if (mDropAnimator != null) {
                     mDropAnimator.start();

--- a/library/src/com/mobeta/android/dslv/DragSortListView.java
+++ b/library/src/com/mobeta/android/dslv/DragSortListView.java
@@ -503,7 +503,7 @@ public class DragSortListView extends ListView {
                         false);
                 int removeMode = a.getInt(
                         R.styleable.DragSortListView_remove_mode,
-                        DragSortController.FLING_RIGHT_REMOVE);
+                        DragSortController.FLING_REMOVE);
                 boolean sortEnabled = a.getBoolean(
                         R.styleable.DragSortListView_sort_enabled,
                         true);

--- a/library/src/com/mobeta/android/dslv/DragSortListView.java
+++ b/library/src/com/mobeta/android/dslv/DragSortListView.java
@@ -513,6 +513,9 @@ public class DragSortListView extends ListView {
                 int dragHandleId = a.getResourceId(
                         R.styleable.DragSortListView_drag_handle_id,
                         0);
+                int flingHandleId = a.getResourceId(
+                        R.styleable.DragSortListView_fling_handle_id,
+                        0);
                 int clickRemoveId = a.getResourceId(
                         R.styleable.DragSortListView_click_remove_id,
                         0);
@@ -522,7 +525,7 @@ public class DragSortListView extends ListView {
                 
                 DragSortController controller = new DragSortController(
                         this, dragHandleId, dragInitMode, removeMode,
-                        clickRemoveId);
+                        clickRemoveId,flingHandleId);
                 controller.setRemoveEnabled(removeEnabled);
                 controller.setSortEnabled(sortEnabled);
                 controller.setBackgroundColor(bgColor);

--- a/library/src/com/mobeta/android/dslv/DragSortListView.java
+++ b/library/src/com/mobeta/android/dslv/DragSortListView.java
@@ -1347,8 +1347,6 @@ public class DragSortListView extends ListView {
     public void removeItem(int which, float velocityX) {
         if (mDragState == IDLE || mDragState == DRAGGING) {
 
-            mDragState = REMOVING;
-        	mRemoveVelocityX = velocityX;
             if (mDragState == IDLE) {
                 // called from outside drag-sort
                 mSrcPos = getHeaderViewsCount() + which;
@@ -1360,6 +1358,9 @@ public class DragSortListView extends ListView {
                     v.setVisibility(View.INVISIBLE);
                 }
             }
+            
+            mDragState = REMOVING;
+        	mRemoveVelocityX = velocityX;
 
             if (mInTouchEvent) {
                 switch (mCancelMethod) {

--- a/library/src/com/mobeta/android/dslv/DragSortListView.java
+++ b/library/src/com/mobeta/android/dslv/DragSortListView.java
@@ -24,32 +24,30 @@ package com.mobeta.android.dslv;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.database.DataSetObserver;
-import android.graphics.Bitmap;
-import android.graphics.PixelFormat;
-import android.graphics.Rect;
-import android.graphics.RectF;
-import android.graphics.drawable.Drawable;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Point;
+import android.graphics.drawable.Drawable;
 import android.os.Environment;
 import android.os.SystemClock;
-import android.text.method.MovementMethod;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.util.SparseBooleanArray;
 import android.util.SparseIntArray;
-import android.view.*;
-import android.view.GestureDetector.SimpleOnGestureListener;
-import android.widget.*;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AbsListView;
+import android.widget.BaseAdapter;
+import android.widget.HeaderViewListAdapter;
+import android.widget.ListAdapter;
+import android.widget.ListView;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.text.ChoiceFormat;
 import java.util.ArrayList;
-import java.util.HashMap;
-
 
 /**
  * ListView subclass that mediates drag and drop resorting of items.
@@ -104,7 +102,7 @@ public class DragSortListView extends ListView {
      * View. If dropped, the dragged item will land in this position.
      */
     private int mFloatPos;
-    
+
     /**
      * The first expanded ListView position that helps represent
      * the drop slot tracking the floating View.
@@ -175,7 +173,7 @@ public class DragSortListView extends ListView {
 
     /**
      * Enable/Disable item dragging
-     *
+     * 
      * @attr name dslv:drag_enabled
      */
     private boolean mDragEnabled = true;
@@ -188,9 +186,9 @@ public class DragSortListView extends ListView {
     private final static int DROPPING = 2;
     private final static int STOPPED = 3;
     private final static int DRAGGING = 4;
-    
+
     private int mDragState = IDLE;
-    
+
     /**
      * Height in pixels to which the originally dragged item
      * is collapsed during a drag-sort. Currently, this value
@@ -257,13 +255,12 @@ public class DragSortListView extends ListView {
      */
     private float mDragDownScrollHeight;
 
-
     /**
      * Maximum drag-scroll speed in pixels per ms. Only used with
      * default linear drag-scroll profile.
      */
     private float mMaxScrollSpeed = 0.5f;
-    
+
     /**
      * Defines the scroll speed during a drag-scroll. User can
      * provide their own; this default is a simple linear profile
@@ -286,7 +283,7 @@ public class DragSortListView extends ListView {
      * Current touch y.
      */
     private int mY;
-    
+
     /**
      * Last touch x.
      */
@@ -387,7 +384,7 @@ public class DragSortListView extends ListView {
      * is directly below).
      */
     private float mSlideFrac = 0.0f;
-    
+
     /**
      * Wraps the user-provided ListAdapter. This is used to wrap each
      * item View given by the user inside another View (currenly
@@ -431,22 +428,22 @@ public class DragSortListView extends ListView {
      */
     private static final int sCacheSize = 3;
     private HeightCache mChildHeightCache = new HeightCache(sCacheSize);
-	
+
     private RemoveAnimator mRemoveAnimator;
 
     private LiftAnimator mLiftAnimator;
 
     private DropAnimator mDropAnimator;
 
-	private boolean mUseRemoveVelocity;
+    private boolean mUseRemoveVelocity;
     private float mRemoveVelocityX = 0;
 
     public DragSortListView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
         int defaultDuration = 150;
-        int removeAnimDuration = defaultDuration; //ms
-        int dropAnimDuration = defaultDuration; //ms
+        int removeAnimDuration = defaultDuration; // ms
+        int dropAnimDuration = defaultDuration; // ms
 
         if (attrs != null) {
             TypedArray a = getContext().obtainStyledAttributes(attrs,
@@ -470,8 +467,8 @@ public class DragSortListView extends ListView {
 
             mSlideRegionFrac = Math.max(0.0f,
                     Math.min(1.0f, 1.0f - a.getFloat(
-                    R.styleable.DragSortListView_slide_shuffle_speed,
-                    0.75f)));
+                            R.styleable.DragSortListView_slide_shuffle_speed,
+                            0.75f)));
 
             mAnimate = mSlideRegionFrac > 0.0f;
 
@@ -522,10 +519,10 @@ public class DragSortListView extends ListView {
                 int bgColor = a.getColor(
                         R.styleable.DragSortListView_float_background_color,
                         Color.BLACK);
-                
+
                 DragSortController controller = new DragSortController(
                         this, dragHandleId, dragInitMode, removeMode,
-                        clickRemoveId,flingHandleId);
+                        clickRemoveId, flingHandleId);
                 controller.setRemoveEnabled(removeEnabled);
                 controller.setSortEnabled(sortEnabled);
                 controller.setBackgroundColor(bgColor);
@@ -543,31 +540,32 @@ public class DragSortListView extends ListView {
         if (removeAnimDuration > 0) {
             mRemoveAnimator = new RemoveAnimator(smoothness, removeAnimDuration);
         }
-        //mLiftAnimator = new LiftAnimator(smoothness, 100);
+        // mLiftAnimator = new LiftAnimator(smoothness, 100);
         if (dropAnimDuration > 0) {
             mDropAnimator = new DropAnimator(smoothness, dropAnimDuration);
         }
 
-        mCancelEvent = MotionEvent.obtain(0,0,MotionEvent.ACTION_CANCEL,0f,0f,0f,0f,0,0f,0f,0,0);
+        mCancelEvent = MotionEvent.obtain(0, 0, MotionEvent.ACTION_CANCEL, 0f, 0f, 0f, 0f, 0, 0f,
+                0f, 0, 0);
 
         // construct the dataset observer
         mObserver = new DataSetObserver() {
-                    private void cancel() {
-                        if (mDragState == DRAGGING) {
-                            cancelDrag();
-                        }
-                    }
+            private void cancel() {
+                if (mDragState == DRAGGING) {
+                    cancelDrag();
+                }
+            }
 
-                    @Override
-                    public void onChanged() {
-                        cancel();
-                    }
+            @Override
+            public void onChanged() {
+                cancel();
+            }
 
-                    @Override
-                    public void onInvalidated() {
-                        cancel();
-                    }
-                };
+            @Override
+            public void onInvalidated() {
+                cancel();
+            }
+        };
     }
 
     /**
@@ -582,7 +580,7 @@ public class DragSortListView extends ListView {
     public float getFloatAlpha() {
         return mCurrFloatAlpha;
     }
-    
+
     /**
      * Set maximum drag scroll speed in positions/second. Only applies
      * if using default ScrollSpeedProfile.
@@ -592,7 +590,7 @@ public class DragSortListView extends ListView {
     public void setMaxScrollSpeed(float max) {
         mMaxScrollSpeed = max;
     }
-    
+
     /**
      * For each DragSortListView Listener interface implemented by
      * <code>adapter</code>, this method calls the appropriate
@@ -623,7 +621,7 @@ public class DragSortListView extends ListView {
 
         super.setAdapter(mAdapterWrapper);
     }
-    
+
     /**
      * As opposed to {@link ListView#getAdapter()}, which returns
      * a heavily wrapped ListAdapter (DragSortListView wraps the
@@ -639,15 +637,14 @@ public class DragSortListView extends ListView {
         }
     }
 
-    
     private class AdapterWrapper extends HeaderViewListAdapter {
         private ListAdapter mAdapter;
-        
+
         public AdapterWrapper(ListAdapter adapter) {
             super(null, null, adapter);
             mAdapter = adapter;
         }
-        
+
         public ListAdapter getAdapter() {
             return mAdapter;
         }
@@ -657,14 +654,16 @@ public class DragSortListView extends ListView {
 
             DragSortItemView v;
             View child;
-            //Log.d("mobeta", "getView: position="+position+" convertView="+convertView);
+            // Log.d("mobeta",
+            // "getView: position="+position+" convertView="+convertView);
             if (convertView != null) {
                 v = (DragSortItemView) convertView;
                 View oldChild = v.getChildAt(0);
 
                 child = mAdapter.getView(position, oldChild, v);
                 if (child != oldChild) {
-                    // shouldn't get here if user is reusing convertViews properly
+                    // shouldn't get here if user is reusing convertViews
+                    // properly
                     v.removeViewAt(0);
                     v.addView(child);
                 }
@@ -686,13 +685,14 @@ public class DragSortListView extends ListView {
     }
 
     private void drawDivider(int expPosition, Canvas canvas) {
-        
+
         final Drawable divider = getDivider();
         final int dividerHeight = getDividerHeight();
-        //Log.d("mobeta", "div="+divider+" divH="+dividerHeight);
-        
+        // Log.d("mobeta", "div="+divider+" divH="+dividerHeight);
+
         if (divider != null && dividerHeight != 0) {
-            final ViewGroup expItem = (ViewGroup) getChildAt(expPosition - getFirstVisiblePosition());
+            final ViewGroup expItem = (ViewGroup) getChildAt(expPosition
+                    - getFirstVisiblePosition());
             if (expItem != null) {
                 final int l = getPaddingLeft();
                 final int r = getWidth() - getPaddingRight();
@@ -708,11 +708,11 @@ public class DragSortListView extends ListView {
                     b = expItem.getBottom() - childHeight;
                     t = b - dividerHeight;
                 }
-                //Log.d("mobeta", "l="+l+" t="+t+" r="+r+" b="+b);
+                // Log.d("mobeta", "l="+l+" t="+t+" r="+r+" b="+b);
 
                 // Have to clip to support ColorDrawable on <= Gingerbread
                 canvas.save();
-                canvas.clipRect(l, t, r, b); 
+                canvas.clipRect(l, t, r, b);
                 divider.setBounds(l, t, r, b);
                 divider.draw(canvas);
                 canvas.restore();
@@ -738,28 +738,28 @@ public class DragSortListView extends ListView {
             // draw the float view over everything
             final int w = mFloatView.getWidth();
             final int h = mFloatView.getHeight();
-            
+
             int x = mFloatLoc.x;
 
             int width = getWidth();
-            if(x<0) 
-            	x = -x;
-			float alphaMod;
-			if (x < width) {
-				alphaMod = ((float) (width - x)) / ((float) width);
-			    alphaMod *= alphaMod;
-			} else {
-				alphaMod = 0;
-			}
-			
-            final int alpha = (int) (255f * mCurrFloatAlpha * alphaMod );
+            if (x < 0)
+                x = -x;
+            float alphaMod;
+            if (x < width) {
+                alphaMod = ((float) (width - x)) / ((float) width);
+                alphaMod *= alphaMod;
+            } else {
+                alphaMod = 0;
+            }
+
+            final int alpha = (int) (255f * mCurrFloatAlpha * alphaMod);
 
             canvas.save();
-            //Log.d("mobeta", "clip rect bounds: " + canvas.getClipBounds());
+            // Log.d("mobeta", "clip rect bounds: " + canvas.getClipBounds());
             canvas.translate(mFloatLoc.x, mFloatLoc.y);
             canvas.clipRect(0, 0, w, h);
 
-            //Log.d("mobeta", "clip rect bounds: " + canvas.getClipBounds());
+            // Log.d("mobeta", "clip rect bounds: " + canvas.getClipBounds());
             canvas.saveLayerAlpha(0, 0, w, h, alpha, Canvas.ALL_SAVE_FLAG);
             mFloatView.draw(canvas);
             canvas.restore();
@@ -781,7 +781,8 @@ public class DragSortListView extends ListView {
     }
 
     private void printPosData() {
-        Log.d("mobeta", "mSrcPos="+mSrcPos+" mFirstExpPos="+mFirstExpPos+" mSecondExpPos="+mSecondExpPos);
+        Log.d("mobeta", "mSrcPos=" + mSrcPos + " mFirstExpPos=" + mFirstExpPos + " mSecondExpPos="
+                + mSecondExpPos);
     }
 
     private class HeightCache {
@@ -925,13 +926,13 @@ public class DragSortListView extends ListView {
 
         int divHeight = getDividerHeight();
 
-        //Log.d("mobeta", "float mid="+mFloatViewMid);
+        // Log.d("mobeta", "float mid="+mFloatViewMid);
 
         int itemPos = startPos;
         int itemTop = startTop;
         if (mFloatViewMid < edge) {
             // scanning up for float position
-            //Log.d("mobeta", "    edge="+edge);
+            // Log.d("mobeta", "    edge="+edge);
             while (itemPos >= 0) {
                 itemPos--;
                 itemHeight = getItemHeight(itemPos);
@@ -943,8 +944,8 @@ public class DragSortListView extends ListView {
 
                 itemTop -= itemHeight + divHeight;
                 edge = getShuffleEdge(itemPos, itemTop);
-                //Log.d("mobeta", "    edge="+edge);
-                
+                // Log.d("mobeta", "    edge="+edge);
+
                 if (mFloatViewMid >= edge) {
                     break;
                 }
@@ -953,7 +954,7 @@ public class DragSortListView extends ListView {
             }
         } else {
             // scanning down for float position
-            //Log.d("mobeta", "    edge="+edge);
+            // Log.d("mobeta", "    edge="+edge);
             final int count = getCount();
             while (itemPos < count) {
                 if (itemPos == count - 1) {
@@ -964,7 +965,7 @@ public class DragSortListView extends ListView {
                 itemTop += divHeight + itemHeight;
                 itemHeight = getItemHeight(itemPos + 1);
                 edge = getShuffleEdge(itemPos + 1, itemTop);
-                //Log.d("mobeta", "    edge="+edge);
+                // Log.d("mobeta", "    edge="+edge);
 
                 // test for hit
                 if (mFloatViewMid < edge) {
@@ -984,7 +985,7 @@ public class DragSortListView extends ListView {
         int oldFirstExpPos = mFirstExpPos;
         int oldSecondExpPos = mSecondExpPos;
         float oldSlideFrac = mSlideFrac;
-        
+
         if (mAnimate) {
             int edgeToEdge = Math.abs(edge - lastEdge);
 
@@ -996,7 +997,7 @@ public class DragSortListView extends ListView {
                 edgeTop = edge;
                 edgeBottom = lastEdge;
             }
-            //Log.d("mobeta", "edgeTop="+edgeTop+" edgeBot="+edgeBottom);
+            // Log.d("mobeta", "edgeTop="+edgeTop+" edgeBot="+edgeBottom);
 
             int slideRgnHeight = (int) (0.5f * mSlideRegionFrac * edgeToEdge);
             float slideRgnHeightF = (float) slideRgnHeight;
@@ -1008,15 +1009,18 @@ public class DragSortListView extends ListView {
                 mFirstExpPos = itemPos - 1;
                 mSecondExpPos = itemPos;
                 mSlideFrac = 0.5f * ((float) (slideEdgeTop - mFloatViewMid)) / slideRgnHeightF;
-                //Log.d("mobeta", "firstExp="+mFirstExpPos+" secExp="+mSecondExpPos+" slideFrac="+mSlideFrac);
+                // Log.d("mobeta",
+                // "firstExp="+mFirstExpPos+" secExp="+mSecondExpPos+" slideFrac="+mSlideFrac);
             } else if (mFloatViewMid < slideEdgeBottom) {
                 mFirstExpPos = itemPos;
                 mSecondExpPos = itemPos;
             } else {
                 mFirstExpPos = itemPos;
                 mSecondExpPos = itemPos + 1;
-                mSlideFrac = 0.5f * (1.0f + ((float) (edgeBottom - mFloatViewMid)) / slideRgnHeightF);
-                //Log.d("mobeta", "firstExp="+mFirstExpPos+" secExp="+mSecondExpPos+" slideFrac="+mSlideFrac);
+                mSlideFrac = 0.5f * (1.0f + ((float) (edgeBottom - mFloatViewMid))
+                        / slideRgnHeightF);
+                // Log.d("mobeta",
+                // "firstExp="+mFirstExpPos+" secExp="+mSecondExpPos+" slideFrac="+mSlideFrac);
             }
 
         } else {
@@ -1035,7 +1039,8 @@ public class DragSortListView extends ListView {
             mSecondExpPos = itemPos;
         }
 
-        if (mFirstExpPos != oldFirstExpPos || mSecondExpPos != oldSecondExpPos || mSlideFrac != oldSlideFrac) {
+        if (mFirstExpPos != oldFirstExpPos || mSecondExpPos != oldSecondExpPos
+                || mSlideFrac != oldSlideFrac) {
             updated = true;
         }
 
@@ -1050,7 +1055,7 @@ public class DragSortListView extends ListView {
 
         return updated;
     }
-    
+
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
@@ -1069,7 +1074,7 @@ public class DragSortListView extends ListView {
         private float mA, mB, mC, mD;
 
         private boolean mCanceled;
-        
+
         public SmoothAnimator(float smoothness, int duration) {
             mAlpha = smoothness;
             mDurationF = (float) duration;
@@ -1100,15 +1105,15 @@ public class DragSortListView extends ListView {
         }
 
         public void onStart() {
-            //stub
+            // stub
         }
 
         public void onUpdate(float frac, float smoothFrac) {
-            //stub
+            // stub
         }
 
         public void onStop() {
-            //stub
+            // stub
         }
 
         @Override
@@ -1140,7 +1145,7 @@ public class DragSortListView extends ListView {
         public LiftAnimator(float smoothness, int duration) {
             super(smoothness, duration);
         }
-        
+
         @Override
         public void onStart() {
             mInitDragDeltaY = mDragDeltaY;
@@ -1152,7 +1157,8 @@ public class DragSortListView extends ListView {
             if (mDragState != DRAGGING) {
                 cancel();
             } else {
-                mDragDeltaY = (int) (smoothFrac * mFinalDragDeltaY + (1f - smoothFrac) * mInitDragDeltaY);
+                mDragDeltaY = (int) (smoothFrac * mFinalDragDeltaY + (1f - smoothFrac)
+                        * mInitDragDeltaY);
                 mFloatLoc.y = mY - mDragDeltaY;
                 doDragFloatView(true);
             }
@@ -1172,7 +1178,7 @@ public class DragSortListView extends ListView {
         public DropAnimator(float smoothness, int duration) {
             super(smoothness, duration);
         }
-        
+
         @Override
         public void onStart() {
             mDropPos = mFloatPos;
@@ -1212,7 +1218,7 @@ public class DragSortListView extends ListView {
             final float deltaY = mFloatLoc.y - targetY;
             final float deltaX = mFloatLoc.x - targetX;
             final float f = 1f - smoothFrac;
-            if (f < Math.abs(deltaY / mInitDeltaY) || f<Math.abs(deltaX / mInitDeltaX)) {
+            if (f < Math.abs(deltaY / mInitDeltaY) || f < Math.abs(deltaX / mInitDeltaX)) {
                 mFloatLoc.y = targetY + (int) (mInitDeltaY * f);
                 mFloatLoc.x = getPaddingLeft() + (int) (mInitDeltaX * f);
                 doDragFloatView(true);
@@ -1231,7 +1237,7 @@ public class DragSortListView extends ListView {
      */
     private class RemoveAnimator extends SmoothAnimator {
 
-    	private float mFloatLocX;
+        private float mFloatLocX;
         private float mFirstStartBlank;
         private float mSecondStartBlank;
 
@@ -1245,7 +1251,7 @@ public class DragSortListView extends ListView {
         public RemoveAnimator(float smoothness, int duration) {
             super(smoothness, duration);
         }
-        
+
         @Override
         public void onStart() {
             mFirstChildHeight = -1;
@@ -1256,24 +1262,20 @@ public class DragSortListView extends ListView {
             mDragState = REMOVING;
 
             mFloatLocX = mFloatLoc.x;
-            if( mUseRemoveVelocity )
-            {
-            	float minVelocity = 2f*getWidth();
-            	if( mRemoveVelocityX == 0)
-            		mRemoveVelocityX = (mFloatLocX < 0 ? -1 : 1)*minVelocity;
-            	else
-            	{
-            		minVelocity *= 2;
-            		if( mRemoveVelocityX < 0 && mRemoveVelocityX > -minVelocity)
-            			mRemoveVelocityX = -minVelocity;
-            		else if( mRemoveVelocityX > 0 && mRemoveVelocityX < minVelocity)
-            			mRemoveVelocityX = minVelocity;
-            	}
+            if (mUseRemoveVelocity) {
+                float minVelocity = 2f * getWidth();
+                if (mRemoveVelocityX == 0) {
+                    mRemoveVelocityX = (mFloatLocX < 0 ? -1 : 1) * minVelocity;
+                } else {
+                    minVelocity *= 2;
+                    if (mRemoveVelocityX < 0 && mRemoveVelocityX > -minVelocity)
+                        mRemoveVelocityX = -minVelocity;
+                    else if (mRemoveVelocityX > 0 && mRemoveVelocityX < minVelocity)
+                        mRemoveVelocityX = minVelocity;
+                }
+            } else {
+                destroyFloatView();
             }
-			else
-			{	
-	            destroyFloatView();
-			}
         }
 
         @Override
@@ -1284,25 +1286,23 @@ public class DragSortListView extends ListView {
             View item = getChildAt(mFirstPos - firstVis);
             ViewGroup.LayoutParams lp;
             int blank;
-            
-            if( mUseRemoveVelocity )
-            {
-				float dt = (float)(SystemClock.uptimeMillis() - mStartTime)/1000;
-				if( dt == 0 )
-					return;
-				float dx =  mRemoveVelocityX*dt;
-				int w = getWidth();
-				mRemoveVelocityX += (mRemoveVelocityX > 0 ? 1 :-1)*dt*w; 
-				mFloatLocX += dx;
-				mFloatLoc.x = (int) mFloatLocX;
-				if( mFloatLocX < w && mFloatLocX > -w)
-				{
-					mStartTime = SystemClock.uptimeMillis();
-					doDragFloatView(true);
-					return;
-				}
+
+            if (mUseRemoveVelocity) {
+                float dt = (float) (SystemClock.uptimeMillis() - mStartTime) / 1000;
+                if (dt == 0)
+                    return;
+                float dx = mRemoveVelocityX * dt;
+                int w = getWidth();
+                mRemoveVelocityX += (mRemoveVelocityX > 0 ? 1 : -1) * dt * w;
+                mFloatLocX += dx;
+                mFloatLoc.x = (int) mFloatLocX;
+                if (mFloatLocX < w && mFloatLocX > -w) {
+                    mStartTime = SystemClock.uptimeMillis();
+                    doDragFloatView(true);
+                    return;
+                }
             }
-			
+
             if (item != null) {
                 if (mFirstChildHeight == -1) {
                     mFirstChildHeight = getChildHeight(mFirstPos, item, false);
@@ -1334,12 +1334,12 @@ public class DragSortListView extends ListView {
         }
     }
 
+    public void removeItem(int which) {
 
-    public void removeItem(int which ) {
-
-    	mUseRemoveVelocity = false;
-    	removeItem( which, 0 );
+        mUseRemoveVelocity = false;
+        removeItem(which, 0);
     }
+
     /**
      * Removes an item from the list and animates the removal.
      *
@@ -1361,18 +1361,18 @@ public class DragSortListView extends ListView {
                     v.setVisibility(View.INVISIBLE);
                 }
             }
-            
+
             mDragState = REMOVING;
-        	mRemoveVelocityX = velocityX;
+            mRemoveVelocityX = velocityX;
 
             if (mInTouchEvent) {
                 switch (mCancelMethod) {
-                case ON_TOUCH_EVENT:
-                    super.onTouchEvent(mCancelEvent);
-                    break;
-                case ON_INTERCEPT_TOUCH_EVENT:
-                    super.onInterceptTouchEvent(mCancelEvent);
-                    break;
+                    case ON_TOUCH_EVENT:
+                        super.onTouchEvent(mCancelEvent);
+                        break;
+                    case ON_INTERCEPT_TOUCH_EVENT:
+                        super.onInterceptTouchEvent(mCancelEvent);
+                        break;
                 }
             }
 
@@ -1383,7 +1383,6 @@ public class DragSortListView extends ListView {
             }
         }
     }
-
 
     /**
      * Move an item, bypassing the drag-sort process. Simply calls
@@ -1464,7 +1463,7 @@ public class DragSortListView extends ListView {
         // must set to avoid cancelDrag being called from the
         // DataSetObserver
         mDragState = REMOVING;
-        
+
         // end it
         if (mRemoveListener != null) {
             mRemoveListener.remove(which);
@@ -1485,7 +1484,7 @@ public class DragSortListView extends ListView {
 
     private void adjustOnReorder() {
         final int firstPos = getFirstVisiblePosition();
-        //Log.d("mobeta", "first="+firstPos+" src="+mSrcPos);
+        // Log.d("mobeta", "first="+firstPos+" src="+mSrcPos);
         if (mSrcPos < firstPos) {
             // collapsed src item is off screen;
             // adjust the scroll after item heights have been fixed
@@ -1494,7 +1493,7 @@ public class DragSortListView extends ListView {
             if (v != null) {
                 top = v.getTop();
             }
-            //Log.d("mobeta", "top="+top+" fvh="+mFloatViewHeight);
+            // Log.d("mobeta", "top="+top+" fvh="+mFloatViewHeight);
             setSelectionFromTop(firstPos - 1, top - getPaddingTop());
         }
     }
@@ -1511,20 +1510,22 @@ public class DragSortListView extends ListView {
      * no floating View.
      */
     public boolean stopDrag(boolean remove) {
-    	mUseRemoveVelocity = false;
-    	return stopDrag( remove, 0 );
+        mUseRemoveVelocity = false;
+        return stopDrag(remove, 0);
     }
+
     public boolean stopDragWithVelocity(boolean remove, float velocityX) {
-    	
-    	mUseRemoveVelocity = true;
-    	return stopDrag( remove, velocityX );
+
+        mUseRemoveVelocity = true;
+        return stopDrag(remove, velocityX);
     }
+
     public boolean stopDrag(boolean remove, float velocityX) {
         if (mFloatView != null) {
             mDragScroller.stopScrolling(true);
-            
+
             if (remove) {
-                removeItem(mSrcPos - getHeaderViewsCount(),velocityX);
+                removeItem(mSrcPos - getHeaderViewsCount(), velocityX);
             } else {
                 if (mDropAnimator != null) {
                     mDropAnimator.start();
@@ -1564,15 +1565,15 @@ public class DragSortListView extends ListView {
             saveTouchCoords(ev);
         }
 
-        //if (mFloatView != null) {
+        // if (mFloatView != null) {
         if (mDragState == DRAGGING) {
             onDragTouchEvent(ev);
-            more = true; //give us more!
+            more = true; // give us more!
         } else {
             // what if float view is null b/c we dropped in middle
             // of drag touch event?
 
-            //if (mDragState != STOPPED) {
+            // if (mDragState != STOPPED) {
             if (mDragState == IDLE) {
                 if (super.onTouchEvent(ev)) {
                     more = true;
@@ -1582,14 +1583,14 @@ public class DragSortListView extends ListView {
             int action = ev.getAction() & MotionEvent.ACTION_MASK;
 
             switch (action) {
-            case MotionEvent.ACTION_CANCEL:
-            case MotionEvent.ACTION_UP:
-                doActionUpOrCancel();
-                break;
-            default:
-                if (more) {
-                    mCancelMethod = ON_TOUCH_EVENT;
-                }
+                case MotionEvent.ACTION_CANCEL:
+                case MotionEvent.ACTION_UP:
+                    doActionUpOrCancel();
+                    break;
+                default:
+                    if (more) {
+                        mCancelMethod = ON_TOUCH_EVENT;
+                    }
             }
         }
 
@@ -1622,7 +1623,6 @@ public class DragSortListView extends ListView {
         mOffsetY = (int) ev.getRawY() - mY;
     }
 
-    
     @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
         if (!mDragEnabled) {
@@ -1644,7 +1644,7 @@ public class DragSortListView extends ListView {
         }
 
         boolean intercept = false;
-        
+
         // the following deals with calls to super.onInterceptTouchEvent
         if (mFloatView != null) {
             // super's touch event canceled in startDrag
@@ -1655,16 +1655,16 @@ public class DragSortListView extends ListView {
             }
 
             switch (action) {
-            case MotionEvent.ACTION_CANCEL:
-            case MotionEvent.ACTION_UP:
-                doActionUpOrCancel();
-                break;
-            default:
-                if (intercept) {
-                    mCancelMethod = ON_TOUCH_EVENT;
-                } else {
-                    mCancelMethod = ON_INTERCEPT_TOUCH_EVENT;
-                }
+                case MotionEvent.ACTION_CANCEL:
+                case MotionEvent.ACTION_UP:
+                    doActionUpOrCancel();
+                    break;
+                default:
+                    if (intercept) {
+                        mCancelMethod = ON_TOUCH_EVENT;
+                    } else {
+                        mCancelMethod = ON_INTERCEPT_TOUCH_EVENT;
+                    }
             }
         }
 
@@ -1674,8 +1674,7 @@ public class DragSortListView extends ListView {
 
         return intercept;
     }
-        
-    
+
     /**
      * Set the width of each drag scroll region by specifying
      * a fraction of the ListView height.
@@ -1687,8 +1686,7 @@ public class DragSortListView extends ListView {
     public void setDragScrollStart(float heightFraction) {
         setDragScrollStarts(heightFraction, heightFraction);
     }
-    
-    
+
     /**
      * Set the width of each drag scroll region by specifying
      * a fraction of the ListView height.
@@ -1732,7 +1730,8 @@ public class DragSortListView extends ListView {
         int currentScrollDir = mDragScroller.getScrollDir();
 
         if (minY > mLastY && minY > mDownScrollStartY && currentScrollDir != DragScroller.DOWN) {
-            // dragged down, it is below the down scroll start and it is not scrolling up
+            // dragged down, it is below the down scroll start and it is not
+            // scrolling up
 
             if (currentScrollDir != DragScroller.STOP) {
                 // moved directly from up scroll to down scroll
@@ -1742,38 +1741,41 @@ public class DragSortListView extends ListView {
             // start scrolling down
             mDragScroller.startScrolling(DragScroller.DOWN);
         } else if (maxY < mLastY && maxY < mUpScrollStartY && currentScrollDir != DragScroller.UP) {
-            // dragged up, it is above the up scroll start and it is not scrolling up
+            // dragged up, it is above the up scroll start and it is not
+            // scrolling up
 
             if (currentScrollDir != DragScroller.STOP) {
                 // moved directly from down scroll to up scroll
                 mDragScroller.stopScrolling(true);
             }
-            
+
             // start scrolling up
             mDragScroller.startScrolling(DragScroller.UP);
         }
-        else if (maxY >= mUpScrollStartY && minY <= mDownScrollStartY && mDragScroller.isScrolling()) {
-            // not in the upper nor in the lower drag-scroll regions but it is still scrolling
+        else if (maxY >= mUpScrollStartY && minY <= mDownScrollStartY
+                && mDragScroller.isScrolling()) {
+            // not in the upper nor in the lower drag-scroll regions but it is
+            // still scrolling
 
             mDragScroller.stopScrolling(true);
         }
     }
-    
+
     private void updateScrollStarts() {
         final int padTop = getPaddingTop();
         final int listHeight = getHeight() - padTop - getPaddingBottom();
         float heightF = (float) listHeight;
-        
+
         mUpScrollStartYF = padTop + mDragUpScrollStartFrac * heightF;
         mDownScrollStartYF = padTop + (1.0f - mDragDownScrollStartFrac) * heightF;
 
         mUpScrollStartY = (int) mUpScrollStartYF;
         mDownScrollStartY = (int) mDownScrollStartYF;
-        
+
         mDragUpScrollHeight = mUpScrollStartYF - padTop;
         mDragDownScrollHeight = padTop + listHeight - mDownScrollStartYF;
     }
-    
+
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
@@ -1829,7 +1831,6 @@ public class DragSortListView extends ListView {
             }
         }
 
-        
         // Finally adjust item visibility
 
         int oldVis = v.getVisibility();
@@ -1860,13 +1861,13 @@ public class DragSortListView extends ListView {
             // first check cache for child height at this position
             int childHeight = mChildHeightCache.get(position);
             if (childHeight != -1) {
-                //Log.d("mobeta", "found child height in cache!");
+                // Log.d("mobeta", "found child height in cache!");
                 return childHeight;
             }
 
             final ListAdapter adapter = getAdapter();
             int type = adapter.getItemViewType(position);
-            
+
             // There might be a better place for checking for the following
             final int typeCount = adapter.getViewTypeCount();
             if (typeCount != mSampleViewTypes.length) {
@@ -2021,10 +2022,12 @@ public class DragSortListView extends ListView {
     private void measureItem(View item) {
         ViewGroup.LayoutParams lp = item.getLayoutParams();
         if (lp == null) {
-            lp = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.FILL_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+            lp = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.FILL_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT);
             item.setLayoutParams(lp);
         }
-        int wspec = ViewGroup.getChildMeasureSpec(mWidthMeasureSpec, getListPaddingLeft() + getListPaddingRight(), lp.width);
+        int wspec = ViewGroup.getChildMeasureSpec(mWidthMeasureSpec, getListPaddingLeft()
+                + getListPaddingRight(), lp.width);
         int hspec;
         if (lp.height > 0) {
             hspec = MeasureSpec.makeMeasureSpec(lp.height, MeasureSpec.EXACTLY);
@@ -2045,16 +2048,16 @@ public class DragSortListView extends ListView {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        //Log.d("mobeta", "onMeasure called");
+        // Log.d("mobeta", "onMeasure called");
         if (mFloatView != null) {
             if (mFloatView.isLayoutRequested()) {
                 measureFloatView();
             }
-            mFloatViewOnMeasured = true; //set to false after layout
+            mFloatViewOnMeasured = true; // set to false after layout
         }
         mWidthMeasureSpec = widthMeasureSpec;
     }
-    
+
     @Override
     protected void layoutChildren() {
         super.layoutChildren();
@@ -2071,33 +2074,32 @@ public class DragSortListView extends ListView {
         }
     }
 
-
     protected boolean onDragTouchEvent(MotionEvent ev) {
         // we are in a drag
         int action = ev.getAction() & MotionEvent.ACTION_MASK;
 
         switch (ev.getAction() & MotionEvent.ACTION_MASK) {
-        case MotionEvent.ACTION_CANCEL:
-            if (mDragState == DRAGGING) {
-                cancelDrag();
-            }
-            doActionUpOrCancel();
-            break;
-        case MotionEvent.ACTION_UP:
-            //Log.d("mobeta", "calling stopDrag from onDragTouchEvent");
-            if (mDragState == DRAGGING) {
-                stopDrag(false);
-            }
-            doActionUpOrCancel();
-            break;
-        case MotionEvent.ACTION_MOVE:
-            continueDrag((int) ev.getX(), (int) ev.getY());
-            break;
+            case MotionEvent.ACTION_CANCEL:
+                if (mDragState == DRAGGING) {
+                    cancelDrag();
+                }
+                doActionUpOrCancel();
+                break;
+            case MotionEvent.ACTION_UP:
+                // Log.d("mobeta", "calling stopDrag from onDragTouchEvent");
+                if (mDragState == DRAGGING) {
+                    stopDrag(false);
+                }
+                doActionUpOrCancel();
+                break;
+            case MotionEvent.ACTION_MOVE:
+                continueDrag((int) ev.getX(), (int) ev.getY());
+                break;
         }
 
         return true;
     }
-    
+
     private boolean mFloatViewInvalidated = false;
 
     private void invalidateFloatView() {
@@ -2165,7 +2167,8 @@ public class DragSortListView extends ListView {
      * a drag in progress.
      */
     public boolean startDrag(int position, View floatView, int dragFlags, int deltaX, int deltaY) {
-        if (mDragState != IDLE || !mInTouchEvent || mFloatView != null || floatView == null || !mDragEnabled) {
+        if (mDragState != IDLE || !mInTouchEvent || mFloatView != null || floatView == null
+                || !mDragEnabled) {
             return false;
         }
 
@@ -2179,19 +2182,19 @@ public class DragSortListView extends ListView {
         mSrcPos = pos;
         mFloatPos = pos;
 
-        //mDragState = dragType;
+        // mDragState = dragType;
         mDragState = DRAGGING;
         mDragFlags = 0;
         mDragFlags |= dragFlags;
 
         mFloatView = floatView;
-        measureFloatView(); //sets mFloatViewHeight
+        measureFloatView(); // sets mFloatViewHeight
 
         mDragDeltaX = deltaX;
         mDragDeltaY = deltaY;
         mDragStartY = mY;
 
-        //updateFloatView(mX - mDragDeltaX, mY - mDragDeltaY);
+        // updateFloatView(mX - mDragDeltaX, mY - mDragDeltaY);
         mFloatLoc.x = mX - mDragDeltaX;
         mFloatLoc.y = mY - mDragDeltaY;
 
@@ -2209,12 +2212,12 @@ public class DragSortListView extends ListView {
         // once float view is created, events are no longer passed
         // to ListView
         switch (mCancelMethod) {
-        case ON_TOUCH_EVENT:
-            super.onTouchEvent(mCancelEvent);
-            break;
-        case ON_INTERCEPT_TOUCH_EVENT:
-            super.onInterceptTouchEvent(mCancelEvent);
-            break;
+            case ON_TOUCH_EVENT:
+                super.onTouchEvent(mCancelEvent);
+                break;
+            case ON_INTERCEPT_TOUCH_EVENT:
+                super.onInterceptTouchEvent(mCancelEvent);
+                break;
         }
 
         requestLayout();
@@ -2250,7 +2253,7 @@ public class DragSortListView extends ListView {
         if (updated) {
             adjustAllItems();
             int scroll = adjustScroll(movePos, moveItem, oldFirstExpPos, oldSecondExpPos);
-            //Log.d("mobeta", "  adjust scroll="+scroll);
+            // Log.d("mobeta", "  adjust scroll="+scroll);
 
             setSelectionFromTop(movePos, moveItem.getTop() + scroll - getPaddingTop());
             layoutChildren();
@@ -2283,7 +2286,7 @@ public class DragSortListView extends ListView {
             mFloatLoc.x = padLeft;
         } else if ((mDragFlags & DRAG_NEG_X) == 0 && floatX < padLeft) {
             mFloatLoc.x = padLeft;
-        }        
+        }
 
         // keep floating view from going past bottom of last header view
         final int numHeaders = getHeaderViewsCount();
@@ -2291,7 +2294,8 @@ public class DragSortListView extends ListView {
         final int firstPos = getFirstVisiblePosition();
         final int lastPos = getLastVisiblePosition();
 
-        //Log.d("mobeta", "nHead="+numHeaders+" nFoot="+numFooters+" first="+firstPos+" last="+lastPos);
+        // Log.d("mobeta",
+        // "nHead="+numHeaders+" nFoot="+numFooters+" first="+firstPos+" last="+lastPos);
         int topLimit = getPaddingTop();
         if (firstPos < numHeaders) {
             topLimit = getChildAt(numHeaders - firstPos - 1).getBottom();
@@ -2312,11 +2316,11 @@ public class DragSortListView extends ListView {
                 bottomLimit = Math.min(getChildAt(mSrcPos - firstPos).getBottom(), bottomLimit);
             }
         }
-        
-        //Log.d("mobeta", "dragView top=" + (y - mDragDeltaY));
-        //Log.d("mobeta", "limit=" + limit);
-        //Log.d("mobeta", "mDragDeltaY=" + mDragDeltaY);
-        
+
+        // Log.d("mobeta", "dragView top=" + (y - mDragDeltaY));
+        // Log.d("mobeta", "limit=" + limit);
+        // Log.d("mobeta", "mDragDeltaY=" + mDragDeltaY);
+
         if (floatY < topLimit) {
             mFloatLoc.y = topLimit;
         } else if (floatY + mFloatViewHeight > bottomLimit) {
@@ -2326,7 +2330,7 @@ public class DragSortListView extends ListView {
         // get y-midpoint of floating view (constrained to ListView bounds)
         mFloatViewMid = mFloatLoc.y + mFloatViewHeightHalf;
     }
-    
+
     private void destroyFloatView() {
         if (mFloatView != null) {
             mFloatView.setVisibility(GONE);
@@ -2450,7 +2454,7 @@ public class DragSortListView extends ListView {
     public interface DragListener {
         public void drag(int from, int to);
     }
-    
+
     /**
      * Your implementation of this has to reorder your ListAdapter! 
      * Make sure to call
@@ -2463,7 +2467,7 @@ public class DragSortListView extends ListView {
     public interface DropListener {
         public void drop(int from, int to);
     }
-    
+
     /**
      * Make sure to call
      * {@link BaseAdapter#notifyDataSetChanged()} or something like it
@@ -2476,14 +2480,15 @@ public class DragSortListView extends ListView {
         public void remove(int which);
     }
 
-    public interface DragSortListener extends DropListener, DragListener, RemoveListener {}
+    public interface DragSortListener extends DropListener, DragListener, RemoveListener {
+    }
 
     public void setDragSortListener(DragSortListener l) {
         setDropListener(l);
         setDragListener(l);
         setRemoveListener(l);
     }
-    
+
     /**
      * Completely custom scroll speed profile. Default increases linearly
      * with position and is constant in time. Create your own by implementing
@@ -2496,7 +2501,7 @@ public class DragSortListView extends ListView {
             mScrollProfile = ssp;
         }
     }
-    
+
     /**
      * Use this to move the check state of an item from one position to another
      * in a drop operation. If you have a choiceMode which is not none, this
@@ -2535,7 +2540,7 @@ public class DragSortListView extends ListView {
         // start and end of the "runs" of checked items, and then moving the
         // runs. Note that moving an item from A to B is essentially a rotation
         // of the range of items in [A, B]. Let's say we have
-        // . . U V X Y Z . . 
+        // . . U V X Y Z . .
         // and move U after Z. This is equivalent to a rotation one step to the
         // left within the range you are moving across:
         // . . V X Y Z U . .
@@ -2553,12 +2558,12 @@ public class DragSortListView extends ListView {
         SparseBooleanArray cip = getCheckedItemPositions();
         int rangeStart = from;
         int rangeEnd = to;
-        if (to<from) {
+        if (to < from) {
             rangeStart = to;
             rangeEnd = from;
         }
         rangeEnd += 1;
-            
+
         int[] runStart = new int[cip.size()];
         int[] runEnd = new int[cip.size()];
         int runCount = buildRunList(cip, rangeStart, rangeEnd, runStart, runEnd);
@@ -2567,15 +2572,15 @@ public class DragSortListView extends ListView {
             // item to false like we do below.
             return;
         }
-        
+
         if (from < to) {
-            for (int i=0; i!=runCount; i++) {
+            for (int i = 0; i != runCount; i++) {
                 setItemChecked(rotate(runStart[i], -1, rangeStart, rangeEnd), true);
                 setItemChecked(rotate(runEnd[i], -1, rangeStart, rangeEnd), false);
             }
-            
+
         } else {
-            for (int i=0; i!=runCount; i++) {
+            for (int i = 0; i != runCount; i++) {
                 setItemChecked(runStart[i], false);
                 setItemChecked(runEnd[i], true);
             }
@@ -2597,38 +2602,38 @@ public class DragSortListView extends ListView {
      */
     public void removeCheckState(int position) {
         SparseBooleanArray cip = getCheckedItemPositions();
-        
+
         if (cip.size() == 0)
             return;
         int[] runStart = new int[cip.size()];
         int[] runEnd = new int[cip.size()];
         int rangeStart = position;
-        int rangeEnd = cip.keyAt(cip.size()-1)+1;
+        int rangeEnd = cip.keyAt(cip.size() - 1) + 1;
         int runCount = buildRunList(cip, rangeStart, rangeEnd, runStart, runEnd);
-        for (int i=0; i!=runCount; i++) {
+        for (int i = 0; i != runCount; i++) {
             if (!(runStart[i] == position || (runEnd[i] < runStart[i] && runEnd[i] > position))) {
                 // Only set a new check mark in front of this run if it does
                 // not contain the deleted position. If it does, we only need
                 // to make it one check mark shorter at the end.
-                setItemChecked(rotate(runStart[i], - 1, rangeStart, rangeEnd), true);
+                setItemChecked(rotate(runStart[i], -1, rangeStart, rangeEnd), true);
             }
-            setItemChecked(rotate(runEnd[i], - 1, rangeStart, rangeEnd), false);
+            setItemChecked(rotate(runEnd[i], -1, rangeStart, rangeEnd), false);
         }
     }
 
     private static int buildRunList(SparseBooleanArray cip, int rangeStart,
             int rangeEnd, int[] runStart, int[] runEnd) {
         int runCount = 0;
-        
+
         int i = findFirstSetIndex(cip, rangeStart, rangeEnd);
-        if(i == -1)
+        if (i == -1)
             return 0;
-        
+
         int position = cip.keyAt(i);
         int currentRunStart = position;
         int currentRunEnd = currentRunStart + 1;
-        for(i++; i < cip.size() && (position = cip.keyAt(i)) < rangeEnd; i++) {
-            if (!cip.valueAt(i))    // not checked => not interesting
+        for (i++; i < cip.size() && (position = cip.keyAt(i)) < rangeEnd; i++) {
+            if (!cip.valueAt(i)) // not checked => not interesting
                 continue;
             if (position == currentRunEnd) {
                 currentRunEnd++;
@@ -2640,7 +2645,7 @@ public class DragSortListView extends ListView {
                 currentRunEnd = position + 1;
             }
         }
-        
+
         if (currentRunEnd == rangeEnd) {
             // rangeStart and rangeEnd are equivalent positions so to be
             // consistent we translate them to the same integer value. That way
@@ -2651,27 +2656,27 @@ public class DragSortListView extends ListView {
         runStart[runCount] = currentRunStart;
         runEnd[runCount] = currentRunEnd;
         runCount++;
-        
+
         if (runCount > 1) {
-            if (runStart[0] == rangeStart && runEnd[runCount-1] == rangeStart) {
+            if (runStart[0] == rangeStart && runEnd[runCount - 1] == rangeStart) {
                 // The last run ends at the end of the range, and the first run
                 // starts at the beginning of the range. So they are actually
                 // part of the same run, except they wrap around the end of the
                 // range. To avoid adjacent runs, we need to merge them.
-                runStart[0] = runStart[runCount-1];
+                runStart[0] = runStart[runCount - 1];
                 runCount--;
             }
         }
         return runCount;
     }
-    
+
     private static int rotate(int value, int offset, int lowerBound, int upperBound) {
         int windowSize = upperBound - lowerBound;
-        
+
         value += offset;
-        if(value < lowerBound) {
+        if (value < lowerBound) {
             value += windowSize;
-        } else if(value >= upperBound) {
+        } else if (value >= upperBound) {
             value -= windowSize;
         }
         return value;
@@ -2687,7 +2692,6 @@ public class DragSortListView extends ListView {
         return i;
     }
 
-
     private static int insertionIndexForKey(SparseBooleanArray sba, int key) {
         int low = 0;
         int high = sba.size();
@@ -2700,7 +2704,6 @@ public class DragSortListView extends ListView {
         }
         return low;
     }
-
 
     /**
      * Interface for controlling
@@ -2728,10 +2731,10 @@ public class DragSortListView extends ListView {
     private class DragScroller implements Runnable {
 
         private boolean mAbort;
-        
+
         private long mPrevTime;
         private long mCurrTime;
-        
+
         private int dy;
         private float dt;
         private long tStart;
@@ -2740,14 +2743,14 @@ public class DragSortListView extends ListView {
         public final static int STOP = -1;
         public final static int UP = 0;
         public final static int DOWN = 1;
-        
+
         private float mScrollSpeed; // pixels per ms
-        
+
         private boolean mScrolling = false;
-        
+
         private int mLastHeader;
         private int mFirstFooter;
-        
+
         public boolean isScrolling() {
             return mScrolling;
         }
@@ -2756,11 +2759,12 @@ public class DragSortListView extends ListView {
             return mScrolling ? scrollDir : STOP;
         }
 
-        public DragScroller() {}
-        
+        public DragScroller() {
+        }
+
         public void startScrolling(int dir) {
             if (!mScrolling) {
-                //Debug.startMethodTracing("dslv-scroll");
+                // Debug.startMethodTracing("dslv-scroll");
                 mAbort = false;
                 mScrolling = true;
                 tStart = SystemClock.uptimeMillis();
@@ -2769,7 +2773,7 @@ public class DragSortListView extends ListView {
                 post(this);
             }
         }
-        
+
         public void stopScrolling(boolean now) {
             if (now) {
                 DragSortListView.this.removeCallbacks(this);
@@ -2778,10 +2782,9 @@ public class DragSortListView extends ListView {
                 mAbort = true;
             }
 
-            //Debug.stopMethodTracing();
+            // Debug.stopMethodTracing();
         }
-        
-        
+
         @Override
         public void run() {
             if (mAbort) {
@@ -2789,7 +2792,7 @@ public class DragSortListView extends ListView {
                 return;
             }
 
-            //Log.d("mobeta", "scroll");
+            // Log.d("mobeta", "scroll");
 
             final int first = getFirstVisiblePosition();
             final int last = getLastVisiblePosition();
@@ -2802,7 +2805,7 @@ public class DragSortListView extends ListView {
 
             if (scrollDir == UP) {
                 View v = getChildAt(0);
-                //Log.d("mobeta", "vtop="+v.getTop()+" padtop="+padTop);
+                // Log.d("mobeta", "vtop="+v.getTop()+" padtop="+padTop);
                 if (v == null) {
                     mScrolling = false;
                     return;
@@ -2812,7 +2815,8 @@ public class DragSortListView extends ListView {
                         return;
                     }
                 }
-                mScrollSpeed = mScrollProfile.getSpeed((mUpScrollStartYF - maxY) / mDragUpScrollHeight, mPrevTime);
+                mScrollSpeed = mScrollProfile.getSpeed((mUpScrollStartYF - maxY)
+                        / mDragUpScrollHeight, mPrevTime);
             } else {
                 View v = getChildAt(last - first);
                 if (v == null) {
@@ -2824,14 +2828,16 @@ public class DragSortListView extends ListView {
                         return;
                     }
                 }
-                mScrollSpeed = -mScrollProfile.getSpeed((minY - mDownScrollStartYF) / mDragDownScrollHeight, mPrevTime);
+                mScrollSpeed = -mScrollProfile.getSpeed((minY - mDownScrollStartYF)
+                        / mDragDownScrollHeight, mPrevTime);
             }
-            
+
             mCurrTime = SystemClock.uptimeMillis();
             dt = (float) (mCurrTime - mPrevTime);
 
             // dy is change in View position of a list item; i.e. positive dy
-            // means user is scrolling up (list item moves down the screen, remember
+            // means user is scrolling up (list item moves down the screen,
+            // remember
             // y=0 is at top of View).
             dy = (int) Math.round(mScrollSpeed * dt);
 
@@ -2864,8 +2870,8 @@ public class DragSortListView extends ListView {
             doDragFloatView(movePos, moveItem, false);
 
             mPrevTime = mCurrTime;
-            //Log.d("mobeta", "  updated prevTime="+mPrevTime);
-            
+            // Log.d("mobeta", "  updated prevTime="+mPrevTime);
+
             post(this);
         }
     }
@@ -2874,7 +2880,7 @@ public class DragSortListView extends ListView {
         StringBuilder mBuilder = new StringBuilder();
 
         File mFile;
-        
+
         private int mNumInBuffer = 0;
         private int mNumFlushes = 0;
 
@@ -2895,7 +2901,7 @@ public class DragSortListView extends ListView {
             }
 
         }
-        
+
         public void startTracking() {
             mBuilder.append("<DSLVStates>\n");
             mNumFlushes = 0;
@@ -2915,7 +2921,7 @@ public class DragSortListView extends ListView {
                 mBuilder.append(first + i).append(",");
             }
             mBuilder.append("</Positions>\n");
-            
+
             mBuilder.append("    <Tops>");
             for (int i = 0; i < children; ++i) {
                 mBuilder.append(getChildAt(i).getTop()).append(",");
@@ -2929,14 +2935,15 @@ public class DragSortListView extends ListView {
 
             mBuilder.append("    <FirstExpPos>").append(mFirstExpPos).append("</FirstExpPos>\n");
             mBuilder.append("    <FirstExpBlankHeight>")
-                            .append(getItemHeight(mFirstExpPos) - getChildHeight(mFirstExpPos))
-                            .append("</FirstExpBlankHeight>\n");
+                    .append(getItemHeight(mFirstExpPos) - getChildHeight(mFirstExpPos))
+                    .append("</FirstExpBlankHeight>\n");
             mBuilder.append("    <SecondExpPos>").append(mSecondExpPos).append("</SecondExpPos>\n");
             mBuilder.append("    <SecondExpBlankHeight>")
-                            .append(getItemHeight(mSecondExpPos) - getChildHeight(mSecondExpPos))
-                            .append("</SecondExpBlankHeight>\n");
+                    .append(getItemHeight(mSecondExpPos) - getChildHeight(mSecondExpPos))
+                    .append("</SecondExpBlankHeight>\n");
             mBuilder.append("    <SrcPos>").append(mSrcPos).append("</SrcPos>\n");
-            mBuilder.append("    <SrcHeight>").append(mFloatViewHeight + getDividerHeight()).append("</SrcHeight>\n");
+            mBuilder.append("    <SrcHeight>").append(mFloatViewHeight + getDividerHeight())
+                    .append("</SrcHeight>\n");
             mBuilder.append("    <ViewHeight>").append(getHeight()).append("</ViewHeight>\n");
             mBuilder.append("    <LastY>").append(mLastY).append("</LastY>\n");
             mBuilder.append("    <FloatY>").append(mFloatViewMid).append("</FloatY>\n");
@@ -2945,7 +2952,7 @@ public class DragSortListView extends ListView {
                 mBuilder.append(getShuffleEdge(first + i, getChildAt(i).getTop())).append(",");
             }
             mBuilder.append("</ShuffleEdges>\n");
-            
+
             mBuilder.append("</DSLVState>\n");
             mNumInBuffer++;
 
@@ -2954,7 +2961,7 @@ public class DragSortListView extends ListView {
                 mNumInBuffer = 0;
             }
         }
-        
+
         public void flush() {
             if (!mTracking) {
                 return;
@@ -2987,10 +2994,7 @@ public class DragSortListView extends ListView {
                 mTracking = false;
             }
         }
-        
 
     }
-
-
 
 }


### PR DESCRIPTION
Hi,

I added new way to remove items - it mimics the way in which notifications are removed from the notification area.
The item can be flinged or moved aside to be removed, and it can be done on the whole item, not just a drag handle.

While removing the item you can't move it up or down, and vice versa, when you're moving the item vertically, you cannot remove it. Because of that, this new mode works only with mDragInitMode set ON_DRAG (actually if you set this remove mode, the mDragInitMode is ignored and behaves as if it was set to ON_DRAG).

Additionaly the TestBedDSLV activity in demo app is modified, so it starts with this new remove mode turned on.
