### PR TITLE
Make AdapterWrapper extend BaseAdapter

### DIFF
--- a/library/src/com/mobeta/android/dslv/DragSortListView.java
+++ b/library/src/com/mobeta/android/dslv/DragSortListView.java
@@ -40,7 +40,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AbsListView;
 import android.widget.BaseAdapter;
-import android.widget.HeaderViewListAdapter;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 
@@ -637,17 +636,73 @@ public class DragSortListView extends ListView {
         }
     }
 
-    private class AdapterWrapper extends HeaderViewListAdapter {
+    private class AdapterWrapper extends BaseAdapter {
         private ListAdapter mAdapter;
 
         public AdapterWrapper(ListAdapter adapter) {
-            super(null, null, adapter);
+            super();
             mAdapter = adapter;
+            
+            mAdapter.registerDataSetObserver(new DataSetObserver() {
+                public void onChanged() {
+                    notifyDataSetChanged();
+                }
+
+                public void onInvalidated() {
+                    notifyDataSetInvalidated();
+                }
+            });
         }
 
         public ListAdapter getAdapter() {
             return mAdapter;
         }
+
+        @Override
+        public long getItemId(int position) {
+            return mAdapter.getItemId(position);
+        }
+
+        @Override
+        public Object getItem(int position) {
+            return mAdapter.getItem(position);
+        }
+
+        @Override
+        public int getCount() {
+            return mAdapter.getCount();
+        }
+
+        @Override
+        public boolean areAllItemsEnabled() {
+            return mAdapter.areAllItemsEnabled();
+        }
+
+        @Override
+        public boolean isEnabled(int position) {
+            return mAdapter.isEnabled(position);
+        }
+        
+        @Override
+        public int getItemViewType(int position) {
+            return mAdapter.getItemViewType(position);
+        }
+
+        @Override
+        public int getViewTypeCount() {
+            return mAdapter.getViewTypeCount();
+        }
+        
+        @Override
+        public boolean hasStableIds() {
+            return mAdapter.hasStableIds();
+        }
+        
+        @Override
+        public boolean isEmpty() {
+            return mAdapter.isEmpty();
+        }
+
 
         @Override
         public View getView(int position, View convertView, ViewGroup parent) {
@@ -664,7 +719,7 @@ public class DragSortListView extends ListView {
                 if (child != oldChild) {
                     // shouldn't get here if user is reusing convertViews
                     // properly
-                    v.removeViewAt(0);
+                        v.removeViewAt(0);
                     v.addView(child);
                 }
             } else {


### PR DESCRIPTION
Enabling fast scrolling on a `DragSortListView` will result in an exception:

```
Reason: java.lang.ClassCastException: com.mobeta.android.dslv.DragSortListView$AdapterWrapper cannot be cast to android.widget.BaseAdapter
```

The `FastScroller` is expecting the list adapter to be an instance of `BaseAdapter`, which isn't the case because the `DragSortListView` wraps it in the inner `AdapterWrapper` class, which extends `HeaderViewListAdapter`, which itself isn't related to `BaseAdapter`. From what I can tell, this was only done because it handles some of the delegation to the wrapped class; the header/footer behavior that it also provides isn't used.

This pull request refactors `AdapterWrapper` to extends `BaseAdapter` by changing the class definition and delegating all of the necessary methods. It's loosely based on the [`AdapterWrapper`](https://github.com/commonsguy/cwac-adapter/blob/master/src/com/commonsware/cwac/adapter/AdapterWrapper.java) from @commonsguy. An alternative might be to include the `cwac-adapter` project as a dependency and extend from `AdapterWrapper`.
