### PR TITLE
Only remove oldChild if it's not null

### DIFF
--- a/library/src/com/mobeta/android/dslv/DragSortListView.java
+++ b/library/src/com/mobeta/android/dslv/DragSortListView.java
@@ -720,7 +720,9 @@ public class DragSortListView extends ListView {
                 if (child != oldChild) {
                     // shouldn't get here if user is reusing convertViews
                     // properly
-                    v.removeViewAt(0);
+                    if (oldChild != null) {
+                        v.removeViewAt(0);
+                    }
                     v.addView(child);
                 }
             } else {


### PR DESCRIPTION
Although the comment next to this code says you should only fall into this branch if you're not reusing views correctly, I believe I am and am landing there because I'm using the drag-sort-listview with a [`MergeAdapter`](https://github.com/commonsguy/cwac-merge) containing some static views. This pull request fixes a crash that occurs if the row to be reused doesn't have any children, which is posible in my situation.
