### PR TITLE
All flings are considered to be remove operations

### DIFF
--- a/library/src/com/mobeta/android/dslv/DragSortController.java
+++ b/library/src/com/mobeta/android/dslv/DragSortController.java
@@ -451,11 +451,11 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
                         int w = mDslv.getWidth();
                         int minPos = w / 5;
                         if (velocityX > mFlingSpeed) {
-                            if (mPositionX > -minPos) {
+                            if (mPositionX > minPos) {
                                 mDslv.stopDragWithVelocity(true, velocityX);
                             }
                         } else if (velocityX < -mFlingSpeed) {
-                            if (mPositionX < minPos) {
+                            if (mPositionX < -minPos) {
                                 mDslv.stopDragWithVelocity(true, velocityX);
                             }
                         }


### PR DESCRIPTION
Here's a small fix for the issue where flinging an item in the list will cause it to be removed regardless of the distance it was flinged. 
