### PR TITLE
Force clickable value to false

### DIFF
--- a/library/src/com/mobeta/android/dslv/DragSortListView.java
+++ b/library/src/com/mobeta/android/dslv/DragSortListView.java
@@ -739,6 +739,11 @@ public class DragSortListView extends ListView {
                 v.addView(child);
             }
 
+            // Set child clickable to false, to prevent style overriding
+            if (child.isClickable()){
+                child.setClickable(false);
+            }
+
             // Set the correct item height given drag state; passed
             // View needs to be measured if measurement is required.
             adjustItem(position + getHeaderViewsCount(), v, true);


### PR DESCRIPTION
Hi,

First of all, I want to thank you for your hard work on this library, which is really useful and fills the drag/drop pattern gap on Android Sdk.

Days ago, I encountered an issue, using the drag-sort-listview : 
I made and set a custom adapter for a DragSortListView with a ayout file which was something like : 

```
    <?xml version="1.0" encoding="utf-8"?>
    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
        android:id="@+id/wrapProg"
        style="@style/button"
        android:layout_width="fill_parent"
        android:layout_height="wrap_content"
        android:orientation="vertical"
         android:padding="4dp" >

         [.....]

     </RelativeLayout>
```

The drag/drop did not work, and I started to search why. I found that in my file styles.xml, the class "button" has a parent attribute set to "@android:style/Widget.Button"; which set clickable property to "true".
And that's why my code was not working as expected, so I set the clickable value of "button" class to false, and all work perfectly.

It's seems, that having dragSortListView with an item clickable, is pretty useless. That's why a made a fix, to set it programmatically on the library.

I hope my use case will help,

Julien
