### PR TITLE
Nullptr fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 DragSortListView
 ================
 
-# NOTICE: No longer maintained.
-
-I do not have much time to devote to this project so I am
-dropping support for the time being. Sorry everybody!
+# NOTICE: maintained to serve the purposes of KeepSafe Software. Nevertheless, please contribute issues and we will gladly take a look at fixing them
 
 News
 ----

--- a/demo/project.properties
+++ b/demo/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-20
+target=android-16
 android.library.reference.1=../library/

--- a/demo/project.properties
+++ b/demo/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-16
+target=android-20
 android.library.reference.1=../library/

--- a/library/project.properties
+++ b/library/project.properties
@@ -12,4 +12,4 @@
 
 android.library=true
 # Project target.
-target=android-7
+target=android-20

--- a/library/project.properties
+++ b/library/project.properties
@@ -12,4 +12,4 @@
 
 android.library=true
 # Project target.
-target=android-20
+target=android-7

--- a/library/src/com/mobeta/android/dslv/DragSortController.java
+++ b/library/src/com/mobeta/android/dslv/DragSortController.java
@@ -277,6 +277,11 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
                 mCurrY = (int) ev.getY();
                 break;
             case MotionEvent.ACTION_UP:
+            	
+            	// Make sure we won't be parsing gestures until a DOWN event is received
+            	mDetectorSawMotionEventDown = false;
+            	mFlingDetectorSawMotionEventDown = false;
+            	
                 if (mRemoveEnabled && mIsRemoving) {
                     int x = mPositionX >= 0 ? mPositionX : -mPositionX;
                     int removePoint = mDslv.getWidth() / 2;


### PR DESCRIPTION
Attempt at fixing the crash when dragging listview items and exiting the view at the same time. It is suspected that some other component is stealing touch events, preventing the GestureDetector to see the DOWN MotionEvent. Without that event, the GestureDetecter eventually calls the onScroll method of the gesturelistener with a null initial event, leading to an application crash
