### PR TITLE
android maven plugin is to low

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@ Copyright 2012 Andreas Schildbach
 			    <plugin>
 			    	<groupId>com.jayway.maven.plugins.android.generation2</groupId>
 			    	<artifactId>android-maven-plugin</artifactId>
-			    	<version>3.3.2</version>
+			    	<version>3.9.0-rc.1</version>
 			    	<extensions>true</extensions>
 			    </plugin>
 				<plugin>


### PR DESCRIPTION
Thank you for your hard working.

When I build use maven, failed with the android-maven plugin.

I use the android-maven-plugin-3.9.0-rc.1, it works.

My environment:

```
ninja@ninja ~/src/drag-sort-listview $ mvn -v
Apache Maven 3.2.3 (33f8c3e1027c3ddde99d3cdebad2656a31e8fdf4; 2014-08-12T04:58:10+08:00)
Maven home: /home/ninja/tool/apache-maven-3.2.3
Java version: 1.7.0_67, vendor: Oracle Corporation
Java home: /usr/lib/jvm/jdk1.7.0_67/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "3.13.0-24-generic", arch: "i386", family: "unix"
```
